### PR TITLE
🎨 Palette: Improve accessibility of flash message close buttons

### DIFF
--- a/views/partials/flash.pug
+++ b/views/partials/flash.pug
@@ -1,18 +1,18 @@
 if messages.errors
   .alert.alert-danger.fade.show
-    button.close(type='button', data-dismiss='alert')
-      i.far.fa-times-circle
+    button.close(type='button', data-dismiss='alert', aria-label='Close')
+      i.far.fa-times-circle(aria-hidden='true')
     for error in messages.errors
       div= error.msg
 if messages.info
   .alert.alert-info.fade.show
-    button.close(type='button', data-dismiss='alert')
-      i.far.fa-times-circle
+    button.close(type='button', data-dismiss='alert', aria-label='Close')
+      i.far.fa-times-circle(aria-hidden='true')
     for info in messages.info
       div= info.msg
 if messages.success
   .alert.alert-success.fade.show
-    button.close(type='button', data-dismiss='alert')
-      i.far.fa-times-circle
+    button.close(type='button', data-dismiss='alert', aria-label='Close')
+      i.far.fa-times-circle(aria-hidden='true')
     for success in messages.success
       div= success.msg


### PR DESCRIPTION
💡 What: Added `aria-label="Close"` to the close buttons in flash messages and `aria-hidden="true"` to the FontAwesome icons.
🎯 Why: Screen reader users need a text alternative to understand that this icon-only button is for closing the notification message.
♿ Accessibility: Ensures the button announces itself as "Close button" rather than just "button", and hides the decorative icon.

---
*PR created automatically by Jules for task [373109317311550556](https://jules.google.com/task/373109317311550556) started by @mbarbine*