### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect in session returnTo

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-07 - Open Redirect via req.session.returnTo
+**Vulnerability:** The application was vulnerable to Open Redirect. The Express middleware in `app.js` naively assigned `req.originalUrl` to `req.session.returnTo`. An attacker could supply a URL like `//evil.com` or `/\evil.com`, which Express would accept. After login, `res.redirect(req.session.returnTo)` would redirect the user to the attacker's domain using a protocol-relative redirect.
+**Learning:** `req.originalUrl` should never be implicitly trusted as a local path for redirection, even if it is the requested path, because Express parses protocol-relative paths (`//domain.com`) which browsers follow externally.
+**Prevention:** Always validate `returnTo` URLs before storing them or redirecting. Use a strict regex like `/^\/[^\/\\]/` to ensure the path starts with exactly one forward slash and no backslashes, defaulting to `/` if invalid.

--- a/app.js
+++ b/app.js
@@ -104,15 +104,17 @@ app.use((req, res, next) => {
 });
 app.use((req, res, next) => {
   // After successful login, redirect back to the intended page
-  if (!req.user
-    && req.path !== '/login'
-    && req.path !== '/signup'
-    && !req.path.match(/^\/auth/)
-    && !req.path.match(/\./)) {
-    req.session.returnTo = req.originalUrl;
-  } else if (req.user
-    && (req.path === '/account' || req.path.match(/^\/api/))) {
-    req.session.returnTo = req.originalUrl;
+  if (!req.user &&
+    req.path !== '/login' &&
+    req.path !== '/signup' &&
+    !req.path.match(/^\/auth/) &&
+    !req.path.match(/\./)) {
+    req.session.returnTo = (req.originalUrl || '').match(/^\/[^\/\\].*/) ?
+      req.originalUrl : '/';
+  } else if (req.user &&
+    (req.path === '/account' || req.path.match(/^\/api/))) {
+    req.session.returnTo = (req.originalUrl || '').match(/^\/[^\/\\].*/) ?
+      req.originalUrl : '/';
   }
   next();
 });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application was vulnerable to Open Redirect. The Express middleware in `app.js` naively assigned `req.originalUrl` to `req.session.returnTo`. An attacker could supply a URL like `//evil.com` or `/\evil.com`, which Express would accept. After login, `res.redirect(req.session.returnTo)` would redirect the user to the attacker's domain using a protocol-relative redirect.
🎯 Impact: Attackers could craft links that lead users to a legitimate login page, but redirect them to a phishing site after successful authentication, stealing credentials or delivering malware.
🔧 Fix: Validated `req.originalUrl` with a regular expression `(req.originalUrl || '').match(/^\/[^\/\\].*/)` before assigning it to `req.session.returnTo`. This ensures the path strictly starts with a single forward slash and defaults to `/` if invalid.
✅ Verification: Tested manually by curling a path like `//evil.com` and `/account`. `//evil.com` correctly defaults to `/`, while `/account` correctly uses `/account`. Automated tests and linters pass.

---
*PR created automatically by Jules for task [13276892154685791976](https://jules.google.com/task/13276892154685791976) started by @mbarbine*