### PR TITLE
🎨 Palette: Add accessible labels to gender radio buttons

### DIFF
--- a/views/account/profile.pug
+++ b/views/account/profile.pug
@@ -26,16 +26,16 @@ block content
       label.col-md-3.col-form-label.font-weight-bold.text-right Gender
       .col-sm-6
         .form-check.form-check-inline
-          input(type='radio', class='form-check-input' checked=user.profile.gender == 'male', name='gender', value='male', data-toggle='radio')
-          label.form-check-label Male
+          input(type='radio', class='form-check-input' checked=user.profile.gender == 'male', name='gender', value='male', data-toggle='radio', id='gender-male')
+          label.form-check-label(for='gender-male') Male
 
         .form-check.form-check-inline
-          input(type='radio', class='form-check-input' checked=user.profile.gender == 'female', name='gender', value='female', data-toggle='radio')
-          label.form-check-label Female
+          input(type='radio', class='form-check-input' checked=user.profile.gender == 'female', name='gender', value='female', data-toggle='radio', id='gender-female')
+          label.form-check-label(for='gender-female') Female
 
         .form-check.form-check-inline
-          input(type='radio', class='form-check-input' checked=user.profile.gender == 'other', name='gender', value='other', data-toggle='radio')
-          label.form-check-label Other
+          input(type='radio', class='form-check-input' checked=user.profile.gender == 'other', name='gender', value='other', data-toggle='radio', id='gender-other')
+          label.form-check-label(for='gender-other') Other
     .form-group.row
       label.col-md-3.col-form-label.font-weight-bold.text-right(for='location') Location
       .col-md-7


### PR DESCRIPTION
💡 **What**: Added `id` attributes to gender radio inputs (`gender-male`, `gender-female`, `gender-other`) and linked them to their corresponding `<label>` elements using the `for` attribute in `views/account/profile.pug`.
🎯 **Why**: Previously, the radio buttons could only be selected by clicking the tiny circle input. By linking the labels, the clickable hit area is significantly increased (users can click the word "Male", "Female", or "Other"), and it provides proper semantic association for screen readers.
♿ **Accessibility**: Improves keyboard and screen reader accessibility by properly associating labels with form inputs.

---
*PR created automatically by Jules for task [3045709743724619930](https://jules.google.com/task/3045709743724619930) started by @mbarbine*