### PR TITLE
🎨 Palette: Add proper labels to gender radio buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Pug Template Radio Button Labels
+**Learning:** Pug templates in this repository using Bootstrap 4 form-checks often have radio inputs without explicit `id`s, and labels without `for` attributes. This breaks the link between label and input for screen readers and prevents clickability on the label.
+**Action:** When adding or maintaining radio/checkbox inputs in `.pug` files (especially `views/account/profile.pug`), always explicitly map `id` on the input to `for` on the corresponding label to ensure screen reader accessibility.

--- a/views/account/profile.pug
+++ b/views/account/profile.pug
@@ -26,16 +26,16 @@ block content
       label.col-md-3.col-form-label.font-weight-bold.text-right Gender
       .col-sm-6
         .form-check.form-check-inline
-          input(type='radio', class='form-check-input' checked=user.profile.gender == 'male', name='gender', value='male', data-toggle='radio')
-          label.form-check-label Male
+          input(type='radio', class='form-check-input', id='gender-male', checked=user.profile.gender == 'male', name='gender', value='male', data-toggle='radio')
+          label.form-check-label(for='gender-male') Male
 
         .form-check.form-check-inline
-          input(type='radio', class='form-check-input' checked=user.profile.gender == 'female', name='gender', value='female', data-toggle='radio')
-          label.form-check-label Female
+          input(type='radio', class='form-check-input', id='gender-female', checked=user.profile.gender == 'female', name='gender', value='female', data-toggle='radio')
+          label.form-check-label(for='gender-female') Female
 
         .form-check.form-check-inline
-          input(type='radio', class='form-check-input' checked=user.profile.gender == 'other', name='gender', value='other', data-toggle='radio')
-          label.form-check-label Other
+          input(type='radio', class='form-check-input', id='gender-other', checked=user.profile.gender == 'other', name='gender', value='other', data-toggle='radio')
+          label.form-check-label(for='gender-other') Other
     .form-group.row
       label.col-md-3.col-form-label.font-weight-bold.text-right(for='location') Location
       .col-md-7


### PR DESCRIPTION
💡 **What:** Added `id` attributes to the "Male", "Female", and "Other" gender radio buttons on the profile page (`views/account/profile.pug`), and mapped the corresponding `<label>` `for` attributes to those IDs.

🎯 **Why:** Previously, the radio buttons did not have explicit IDs, and their labels lacked `for` attributes. This breaks the link between the label and the input, meaning screen readers cannot announce what the radio button is for, and users cannot click the label text to select the radio button (a common accessibility and usability expectation). By explicitly linking them, we ensure full screen reader compatibility and a larger clickable area for the options.

♿ **Accessibility:** Fixes WCAG 1.3.1 (Info and Relationships) and 4.1.2 (Name, Role, Value) by programmatically associating labels with their radio inputs, allowing screen readers to correctly read the option and making the options clickable via their labels.

Recorded learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [6014619152672959250](https://jules.google.com/task/6014619152672959250) started by @mbarbine*