### PR TITLE
🎨 Palette: Add proper form labels and ids to Twilio API view

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-24 - Pug Template Radio Button Labels
 **Learning:** Pug templates in this repository using Bootstrap 4 form-checks often have radio inputs without explicit `id`s, and labels without `for` attributes. This breaks the link between label and input for screen readers and prevents clickability on the label.
 **Action:** When adding or maintaining radio/checkbox inputs in `.pug` files (especially `views/account/profile.pug`), always explicitly map `id` on the input to `for` on the corresponding label to ensure screen reader accessibility.
+## 2024-05-18 - Form Input Accessibility
+**Learning:** Found that custom form blocks or copy-pasted blocks in pug templates sometimes do not have explicitly added and mapped `for` and `id` attributes on inputs and labels, especially in older API views like Twilio API. This impacts screen reader accessibility.
+**Action:** When working with Pug templates and form groups in this repository, explicitly add and map `for` and `id` attributes on all inputs (especially custom inputs) to ensure screen reader accessibility. Check that copy-pasted form blocks do not retain stale `for` attributes.

--- a/views/api/twilio.pug
+++ b/views/api/twilio.pug
@@ -24,11 +24,11 @@ block content
       form(role='form', method='POST')
         input(type='hidden', name='_csrf', value=_csrf)
         .form-group
-          label.control-label Number to text
-          input.form-control(type='text', name='number', autofocus)
+          label.control-label(for='number') Number to text
+          input.form-control(type='text', name='number', id='number', autofocus)
         .form-group
-          label.control-label Message
-          input.form-control(type='text', name='message')
+          label.control-label(for='message') Message
+          input.form-control(type='text', name='message', id='message')
         button.btn.btn-raised(type='submit')
           i.fas.fa-location-arrow.fa-sm
           | Send


### PR DESCRIPTION
💡 What: The UX enhancement added: Added explicit `for` and `id` attributes to the "Number to text" and "Message" input fields and their labels.
🎯 Why: The user problem it solves: The previous form fields were not accessible for screen readers because the labels were not explicitly linked to the inputs. Adding these attributes properly binds the elements, improving accessibility.
📸 Before/After: Visuals remained the same, but the underlying accessibility has been improved. 
♿ Accessibility: Any a11y improvements made: The form is now properly understandable by screen readers due to explicit `for`/`id` links, preventing orphans form labels.

---
*PR created automatically by Jules for task [2237891257763174050](https://jules.google.com/task/2237891257763174050) started by @mbarbine*