### PR TITLE
🎨 Palette: Add for and id attributes to file upload form

### DIFF
--- a/views/api/upload.pug
+++ b/views/api/upload.pug
@@ -21,7 +21,7 @@ block content
       form(role='form', enctype='multipart/form-data', method='POST')
         input(type='hidden', name='_csrf', value=_csrf)
         .form-group
-          label.col-form-label.font-weight-bold File Input
+          label.col-form-label.font-weight-bold(for='myFile') File Input
           .col-md-6
-            input(type='file', name='myFile')
+            input(type='file', name='myFile', id='myFile')
         button.btn.btn-primary(type='submit') Submit


### PR DESCRIPTION
💡 What: Added `for` attribute to the "File Input" label and a corresponding `id` to the file input in the upload view (`views/api/upload.pug`).
🎯 Why: Without these attributes, the label and input were completely disconnected. Adding them improves screen reader compatibility and allows users to click the label to trigger the file input.
♿ Accessibility: Ensures the input has an accessible name, satisfying WCAG criteria for label association.

---
*PR created automatically by Jules for task [7539222661642933063](https://jules.google.com/task/7539222661642933063) started by @mbarbine*