### PR TITLE
🎨 Palette: Improve flash message accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-05-18 - Form Input Accessibility
 **Learning:** Found that custom form blocks or copy-pasted blocks in pug templates sometimes do not have explicitly added and mapped `for` and `id` attributes on inputs and labels, especially in older API views like Twilio API. This impacts screen reader accessibility.
 **Action:** When working with Pug templates and form groups in this repository, explicitly add and map `for` and `id` attributes on all inputs (especially custom inputs) to ensure screen reader accessibility. Check that copy-pasted form blocks do not retain stale `for` attributes.
+## 2026-03-17 - Added role='alert' to Flash Messages
+**Learning:** Found an accessibility issue pattern where flash messages visually appeared but weren't automatically announced by screen readers due to missing ARIA roles. Additionally, duplicate close icons (one missing `aria-hidden`) caused redundant reading.
+**Action:** Always add `role='alert'` to flash message containers and verify that decorative icons inside icon-only buttons have a single instance with `aria-hidden='true'`.

--- a/views/partials/flash.pug
+++ b/views/partials/flash.pug
@@ -1,21 +1,18 @@
 if messages.errors
-  .alert.alert-danger.fade.show
+  .alert.alert-danger.fade.show(role='alert')
     button.close(type='button', data-dismiss='alert', aria-label='Close')
-      i.far.fa-times-circle
       i.far.fa-times-circle(aria-hidden='true')
     for error in messages.errors
       div= error.msg
 if messages.info
-  .alert.alert-info.fade.show
+  .alert.alert-info.fade.show(role='alert')
     button.close(type='button', data-dismiss='alert', aria-label='Close')
-      i.far.fa-times-circle
       i.far.fa-times-circle(aria-hidden='true')
     for info in messages.info
       div= info.msg
 if messages.success
-  .alert.alert-success.fade.show
+  .alert.alert-success.fade.show(role='alert')
     button.close(type='button', data-dismiss='alert', aria-label='Close')
-      i.far.fa-times-circle
       i.far.fa-times-circle(aria-hidden='true')
     for success in messages.success
       div= success.msg


### PR DESCRIPTION
💡 **What:** Added `role="alert"` to all `.alert` containers inside `views/partials/flash.pug` and removed an accidentally duplicated `i.far.fa-times-circle` icon inside the close buttons.

🎯 **Why:** Flash messages (success, info, errors) appear dynamically but without the alert role, screen readers will not proactively announce them to users. The duplicate decorative icon also caused redundant DOM elements.

📸 **Before/After:** The visual presentation of the alerts remains unchanged, but they are now semantically sound.

♿ **Accessibility:**
- Automatically announced messages for screen reader users via `role="alert"`.
- Cleaned up the close button so it relies strictly on its `aria-label="Close"` and hides the singular decorative icon via `aria-hidden="true"`.

---
*PR created automatically by Jules for task [8372561956752991186](https://jules.google.com/task/8372561956752991186) started by @mbarbine*