### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limit to forgot password endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** Unsanitized user inputs (req.body) are used directly in Mongoose queries and string validation functions without type coercion.
 **Learning:** Bypassing string coercion allows attackers to submit objects like `{"$ne": null}` as request parameters. When passed to Mongoose `findOne()`, this results in NoSQL injection, potentially allowing authentication bypass. If passed to `validator` functions, it can crash the Node.js application.
 **Prevention:** Always explicitly cast user input to a string, e.g., `String(req.body.email)`, before passing to queries or validators to ensure the application only processes primitive types.
+## 2024-03-17 - Rate limiting on Password Reset
+**Vulnerability:** Missing rate limit on `/forgot` endpoint allowing potential DoS and email flooding.
+**Learning:** Legacy endpoints sending emails or SMS must be explicitly protected by rate limiters to prevent abuse.
+**Prevention:** Always apply `express-rate-limit` (or similar) to any route that triggers external side-effects like email delivery.

--- a/app.js
+++ b/app.js
@@ -150,6 +150,13 @@ const loginRateLimiter = rateLimit({
     'Too many login attempts from this IP, please try again after 30 minutes',
 });
 
+const forgotPasswordRateLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour window
+  max: 5, // start blocking after 5 requests
+  message:
+    'Too many password reset attempts from this IP, please try again after an hour',
+});
+
 /**
  * Primary app routes.
  */
@@ -158,7 +165,7 @@ app.get('/login', userController.getLogin);
 app.post('/login', loginRateLimiter, userController.postLogin);
 app.get('/logout', userController.logout);
 app.get('/forgot', userController.getForgot);
-app.post('/forgot', userController.postForgot);
+app.post('/forgot', forgotPasswordRateLimiter, userController.postForgot);
 app.get('/reset/:token', userController.getReset);
 app.post('/reset/:token', userController.postReset);
 app.get('/signup', userController.getSignup);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/forgot` password reset endpoint was missing rate-limiting protections, allowing potential abuse via email flooding and Denial of Service (DoS).
🎯 Impact: Attackers could repeatedly trigger password reset emails, consuming application resources and spamming user inboxes.
🔧 Fix: Implemented a new `forgotPasswordRateLimiter` using the pre-existing `express-rate-limit` middleware, capping requests to 5 per hour.
✅ Verification: Code reviewed to ensure the limiter is applied specifically to the `app.post('/forgot')` route without breaking normal authentication flows.

---
*PR created automatically by Jules for task [5840029430586536825](https://jules.google.com/task/5840029430586536825) started by @mbarbine*