### PR TITLE
🎨 Palette: Improve accessibility of flash messages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2024-05-18 - Form Input Accessibility
 **Learning:** Found that custom form blocks or copy-pasted blocks in pug templates sometimes do not have explicitly added and mapped `for` and `id` attributes on inputs and labels, especially in older API views like Twilio API. This impacts screen reader accessibility.
 **Action:** When working with Pug templates and form groups in this repository, explicitly add and map `for` and `id` attributes on all inputs (especially custom inputs) to ensure screen reader accessibility. Check that copy-pasted form blocks do not retain stale `for` attributes.
+
+## 2024-05-24 - Flash Message Accessibility Roles
+**Learning:** Dynamic flash message containers (like `.alert`) often visually convey information without automatically notifying screen readers. Using `role='alert'` ensures screen readers announce the contents of the container immediately upon display. Additionally, when using icon-only close buttons, ensure there is only a single decorative icon and apply `aria-hidden='true'` to prevent redundant announcements.
+**Action:** Always add `role='alert'` to flash message or toast containers and clean up duplicate, visually identical, decorative icons inside buttons for improved accessibility.

--- a/views/partials/flash.pug
+++ b/views/partials/flash.pug
@@ -1,21 +1,18 @@
 if messages.errors
-  .alert.alert-danger.fade.show
+  .alert.alert-danger.fade.show(role='alert')
     button.close(type='button', data-dismiss='alert', aria-label='Close')
-      i.far.fa-times-circle
       i.far.fa-times-circle(aria-hidden='true')
     for error in messages.errors
       div= error.msg
 if messages.info
-  .alert.alert-info.fade.show
+  .alert.alert-info.fade.show(role='alert')
     button.close(type='button', data-dismiss='alert', aria-label='Close')
-      i.far.fa-times-circle
       i.far.fa-times-circle(aria-hidden='true')
     for info in messages.info
       div= info.msg
 if messages.success
-  .alert.alert-success.fade.show
+  .alert.alert-success.fade.show(role='alert')
     button.close(type='button', data-dismiss='alert', aria-label='Close')
-      i.far.fa-times-circle
       i.far.fa-times-circle(aria-hidden='true')
     for success in messages.success
       div= success.msg


### PR DESCRIPTION
💡 **What:** Added `role='alert'` to flash message notification containers and cleaned up the `aria-hidden` decorative close icons to prevent duplicate screen reader announcements.
🎯 **Why:** Flash messages are dynamically injected user notifications. Without a proper ARIA role, users relying on screen readers wouldn't be automatically notified when a success or error message appears on the screen.
♿ **Accessibility:** This directly improves WCAG compliance for dynamic content updates by using standard alert roles and pruning non-semantic duplicate icon elements.

---
*PR created automatically by Jules for task [6482650949354687381](https://jules.google.com/task/6482650949354687381) started by @mbarbine*