### PR TITLE
🎨 Palette: Add alt attributes to API Sandbox logos

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -23,3 +23,6 @@
 ## 2024-05-24 - Flash Message Accessibility Roles
 **Learning:** Dynamic flash message containers (like `.alert`) often visually convey information without automatically notifying screen readers. Using `role='alert'` ensures screen readers announce the contents of the container immediately upon display. Additionally, when using icon-only close buttons, ensure there is only a single decorative icon and apply `aria-hidden='true'` to prevent redundant announcements.
 **Action:** Always add `role='alert'` to flash message or toast containers and clean up duplicate, visually identical, decorative icons inside buttons for improved accessibility.
+## 2026-03-20 - Missing alt attributes on large image grids
+**Learning:** Found an accessibility issue pattern where large collections of images (like the 24 API Sandbox logos in views/api/index.pug) consistently missed `alt` attributes, likely due to copy-pasting the initial grid cell structure.
+**Action:** Always verify `alt` attributes are present when creating or modifying grids or lists of images, ensuring each image has descriptive alternative text, even if the text immediately follows the image visually.

--- a/views/api/index.pug
+++ b/views/api/index.pug
@@ -9,143 +9,143 @@ block content
       a(href='/api/github', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/2AaBlpf.png', height=40)
+            img(src='https://i.imgur.com/2AaBlpf.png', height=40, alt='GitHub')
             |  GitHub
     .col-md-4
       a(href='/api/twitter', style='color: #fff')
         .card(style='background-color: #00abf0').mb-3
           .card-body
-            img(src='https://i.imgur.com/EYA2FO1.png', height=40)
+            img(src='https://i.imgur.com/EYA2FO1.png', height=40, alt='Twitter')
             |  Twitter
     .col-md-4
       a(href='/api/facebook', style='color: #fff')
         .card(style='background-color: #3b5998').mb-3
           .card-body
-            img(src='https://i.imgur.com/jiztYCH.png', height=40)
+            img(src='https://i.imgur.com/jiztYCH.png', height=40, alt='Facebook')
             |  Facebook
     .col-md-4
       a(href='/api/foursquare', style='color: #fff')
         .card(style='background-color: #1cafec').mb-3
           .card-body
-            img(src='https://i.imgur.com/PixH9li.png', height=40)
+            img(src='https://i.imgur.com/PixH9li.png', height=40, alt='Foursquare')
             |  Foursquare
     .col-md-4
       a(href='/api/instagram', style='color: #fff')
         .card(style='background-color: #947563').mb-3
           .card-body
-            img(src='https://i.imgur.com/aRc6LUJ.png', height=40)
+            img(src='https://i.imgur.com/aRc6LUJ.png', height=40, alt='Instagram')
             |  Instagram
     .col-md-4
       a(href='/api/lastfm', style='color: #fff')
         .card(style='background-color: #d21309').mb-3
           .card-body
-            img(src='https://i.imgur.com/KfZY876.png', height=40)
+            img(src='https://i.imgur.com/KfZY876.png', height=40, alt='Last.fm')
             |  Last.fm
     .col-md-4
       a(href='/api/nyt', style='color: #fff')
         .card(style='background-color: #454442').mb-3
           .card-body
-            img(src='https://i.imgur.com/e3sjmYj.png', height=40)
+            img(src='https://i.imgur.com/e3sjmYj.png', height=40, alt='New York Times')
             |  New York Times
     .col-md-4
       a(href='/api/steam', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/6WXcNeg.png', height=40)
+            img(src='https://i.imgur.com/6WXcNeg.png', height=40, alt='Steam')
             |  Steam
     .col-md-4
       a(href='/api/twitch', style='color: #fff')
         .card(style='background-color: #6441a5').mb-3
           .card-body
-            img(src='https://i.imgur.com/dWEkSRX.png', height=40)
+            img(src='https://i.imgur.com/dWEkSRX.png', height=40, alt='Twitch')
             |  Twitch
     .col-md-4
       a(href='/api/stripe', style='color: #fff')
         .card(style='background-color: #3da8e5').mb-3
           .card-body
-            img(src='https://i.imgur.com/w3s2RvW.png', height=40)
+            img(src='https://i.imgur.com/w3s2RvW.png', height=40, alt='Stripe')
             |  Stripe
     .col-md-4
       a(href='/api/paypal', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNc0iaX.png', height=40)
+            img(src='https://i.imgur.com/JNc0iaX.png', height=40, alt='PayPal')
             |  PayPal
     .col-md-4
       a(href='/api/quickbooks', style='color: #fff')
         .card(style='background-color: #0077C5').mb-3
           .card-body
-            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40)
+            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='QuickBooks')
             |  QuickBooks
     .col-md-4
       a(href='/api/twilio', style='color: #fff')
         .card(style='background-color: #fd0404').mb-3
           .card-body
-            img(src='https://i.imgur.com/mEUd6zM.png', height=40)
+            img(src='https://i.imgur.com/mEUd6zM.png', height=40, alt='Twilio')
             |  Twilio
     .col-md-4
       a(href='/api/tumblr', style='color: #fff')
         .card(style='background-color: #304e6c').mb-3
           .card-body
-            img(src='https://i.imgur.com/rZGQShS.png', height=40)
+            img(src='https://i.imgur.com/rZGQShS.png', height=40, alt='Tumblr')
             |  Tumblr
     .col-md-4
       a(href='/api/scraping', style='color: #fff')
         .card(style='background-color: #ff6500').mb-3
           .card-body
-            img(src='https://i.imgur.com/RGCVvyR.png', height=40)
+            img(src='https://i.imgur.com/RGCVvyR.png', height=40, alt='Web Scraping')
             |  Web Scraping
     .col-md-4
       a(href='/api/clockwork', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/YcdxZ5F.png', height=40)
+            img(src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='Clockwork SMS')
             |  Clockwork SMS
     .col-md-4
       a(href='/api/lob', style='color: #fff')
         .card(style='background-color: #176992').mb-3
           .card-body
-            img(src='https://i.imgur.com/bmgfsSg.png', height=40)
+            img(src='https://i.imgur.com/bmgfsSg.png', height=40, alt='Lob')
             |  Lob
     .col-md-4
       a(href='/api/upload', style='color: #1565c0')
         .card(style='background-color: #fff').mb-3
           .card-body
-            img(src='https://i.imgur.com/UPTzIdC.png', height=40)
+            img(src='https://i.imgur.com/UPTzIdC.png', height=40, alt='File Upload')
             |  File Upload
     .col-md-4
       a(href='/api/pinterest', style='color: #fff')
         .card(style='background-color: #bd081c').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNNRQSm.png', height=40)
+            img(src='https://i.imgur.com/JNNRQSm.png', height=40, alt='Pinterest')
             |  Pinterest
     .col-md-4
       a(href='/api/google-maps', style='color: #fff')
         .card(style='background-color: #20a360').mb-3
           .card-body
-            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40)
+            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='Google Maps')
             |  Google Maps
     .col-md-4
       a(href='/api/here-maps', style='color: #0f1621')
         .card(style='background-color: #d1f6f3').mb-3
           .card-body
-            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40)
+            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='HERE Maps')
             |  HERE Maps
     .col-md-4
       a(href='/api/chart', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40)
+            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='Chart.js + Alpha Vantage')
             |  Chart.js + Alpha Vantage
     .col-md-4
       a(href='/api/google/drive', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40)
+            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='Google Drive')
             |  Google Drive
     .col-md-4
       a(href='/api/google/sheets', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40)
+            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='Google Sheets')
             |  Google Sheets


### PR DESCRIPTION
💡 **What:** Added descriptive `alt` attributes to all 24 API logo images in the API Sandbox template (`views/api/index.pug`).
🎯 **Why:** Previously, these images lacked `alt` attributes. This is a critical accessibility failure because screen readers default to reading the raw image URLs (e.g., `https://i.imgur.com/...`), which provides no context and degrades the user experience for visually impaired users.
📸 **Before/After:** No visual changes were made; the layout is identical.
♿ **Accessibility:** This directly addresses WCAG 1.1.1 (Non-text Content), ensuring that all non-decorative images have a meaningful text alternative.

---
*PR created automatically by Jules for task [8789242651130596665](https://jules.google.com/task/8789242651130596665) started by @mbarbine*