### PR TITLE
⚡ Bolt: [performance improvement] Cache Last.fm API requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-03-13 - [Caching External API Calls]
 **Learning:** Optimizations involving `req.body` and Mongoose queries (e.g. `.lean()`) trigger CodeQL data flow rules that falsely flag pre-existing missing rate limits as 'new alerts', forcing developers to modify unapproved files.
 **Action:** Caching external API requests (e.g., GitHub, NYT) is a highly effective, low-risk Bolt performance win that bypasses DB-related static analysis warnings and avoids hitting rate limits on external services.
+
+## 2026-03-22 - [Caching Static External API Calls]
+**Learning:** Some controller endpoints (like `/api/lastfm`) make external API calls for static data (e.g., info about a specific artist "Roniit") that does not vary per user. Fetching this data from external APIs on every single user request introduces massive, unnecessary latency and wastes API rate limits.
+**Action:** When an endpoint fetches external data that is static across all users and uses a global application key (not a user-specific OAuth token), implement a module-level cache (e.g., `let cache = null; let cacheTime = 0;`) with a reasonable duration (e.g., 5 minutes) to serve the data instantly and reduce network overhead.

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -224,7 +224,19 @@ exports.getNewYorkTimes = (req, res, next) => {
  * GET /api/lastfm
  * Last.fm API example.
  */
+let lastfmCache = null;
+let lastfmCacheTime = 0;
+const LASTFM_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
 exports.getLastfm = async (req, res, next) => {
+  // ⚡ Bolt: Cache Last.fm API requests for static artist data to reduce external API calls and latency
+  if (lastfmCache && Date.now() - lastfmCacheTime < LASTFM_CACHE_DURATION) {
+    return res.render('api/lastfm', {
+      title: 'Last.fm API',
+      artist: lastfmCache
+    });
+  }
+
   const lastfm = new LastFmNode({
     api_key: process.env.LASTFM_KEY,
     secret: process.env.LASTFM_SECRET
@@ -284,6 +296,10 @@ exports.getLastfm = async (req, res, next) => {
       topTracks,
       topAlbums
     };
+
+    lastfmCache = artist;
+    lastfmCacheTime = Date.now();
+
     res.render('api/lastfm', {
       title: 'Last.fm API',
       artist


### PR DESCRIPTION
**💡 What:** Implemented a 5-minute memory cache for the `/api/lastfm` endpoint in `controllers/api.js`.

**🎯 Why:** The endpoint fetches data for a hardcoded artist ("Roniit") to serve as an API code example. Since this data is static across all users and uses the global `LASTFM_KEY` (not a user-specific OAuth token), making three concurrent API calls to Last.fm on every single request wastes rate limits and introduces unnecessary latency.

**📊 Impact:** 
- Reduces external network requests to Last.fm from 3 per user request to 0 (for 5 minutes after a cache miss).
- Significantly improves response time for the `/api/lastfm` route on subsequent requests by serving data directly from memory.

**🔬 Measurement:** 
Run `pnpm start` and visit the `/api/lastfm` route multiple times. The first load will take typical network latency time, while subsequent loads within 5 minutes will be nearly instantaneous. Tests and linters were run successfully.

_Note: This optimization was chosen over DB `.lean()` optimizations to avoid CodeQL static analysis issues, as documented in `.jules/bolt.md`._

---
*PR created automatically by Jules for task [8520154970389786372](https://jules.google.com/task/8520154970389786372) started by @mbarbine*