### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure TLS fallback in nodemailer

### DIFF
--- a/controllers/contact.js
+++ b/controllers/contact.js
@@ -61,31 +61,6 @@ exports.postContact = (req, res) => {
       res.redirect('/contact');
     })
     .catch((err) => {
-      if (err.message === 'self signed certificate in certificate chain') {
-        console.log('WARNING: Self signed certificate in certificate chain. Retrying with the self signed certificate. Use a valid certificate if in production.');
-        transporter = nodemailer.createTransport({
-          service: 'SendGrid',
-          auth: {
-            user: process.env.SENDGRID_USER,
-            pass: process.env.SENDGRID_PASSWORD
-          },
-          tls: {
-            rejectUnauthorized: false
-          }
-        });
-        return transporter.sendMail(mailOptions);
-      }
-      console.log('ERROR: Could not send contact email after security downgrade.\n', err);
-      req.flash('errors', { msg: 'Error sending the message. Please try again shortly.' });
-      return false;
-    })
-    .then((result) => {
-      if (result) {
-        req.flash('success', { msg: 'Email has been sent successfully!' });
-        return res.redirect('/contact');
-      }
-    })
-    .catch((err) => {
       console.log('ERROR: Could not send contact email.\n', err);
       req.flash('errors', { msg: 'Error sending the message. Please try again shortly.' });
       return res.redirect('/contact');

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -357,24 +357,7 @@ exports.getVerifyEmail = (req, res, next) => {
         req.flash('info', { msg: `An e-mail has been sent to ${req.user.email} with further instructions.` });
       })
       .catch((err) => {
-        if (err.message === 'self signed certificate in certificate chain') {
-          console.log('WARNING: Self signed certificate in certificate chain. Retrying with the self signed certificate. Use a valid certificate if in production.');
-          transporter = nodemailer.createTransport({
-            service: 'SendGrid',
-            auth: {
-              user: process.env.SENDGRID_USER,
-              pass: process.env.SENDGRID_PASSWORD
-            },
-            tls: {
-              rejectUnauthorized: false
-            }
-          });
-          return transporter.sendMail(mailOptions)
-            .then(() => {
-              req.flash('info', { msg: `An e-mail has been sent to ${req.user.email} with further instructions.` });
-            });
-        }
-        console.log('ERROR: Could not send verifyEmail email after security downgrade.\n', err);
+        console.log('ERROR: Could not send verifyEmail email.\n', err);
         req.flash('errors', { msg: 'Error sending the email verification message. Please try again shortly.' });
         return err;
       });
@@ -442,24 +425,7 @@ exports.postReset = (req, res, next) => {
         req.flash('success', { msg: 'Success! Your password has been changed.' });
       })
       .catch((err) => {
-        if (err.message === 'self signed certificate in certificate chain') {
-          console.log('WARNING: Self signed certificate in certificate chain. Retrying with the self signed certificate. Use a valid certificate if in production.');
-          transporter = nodemailer.createTransport({
-            service: 'SendGrid',
-            auth: {
-              user: process.env.SENDGRID_USER,
-              pass: process.env.SENDGRID_PASSWORD
-            },
-            tls: {
-              rejectUnauthorized: false
-            }
-          });
-          return transporter.sendMail(mailOptions)
-            .then(() => {
-              req.flash('success', { msg: 'Success! Your password has been changed.' });
-            });
-        }
-        console.log('ERROR: Could not send password reset confirmation email after security downgrade.\n', err);
+        console.log('ERROR: Could not send password reset confirmation email.\n', err);
         req.flash('warning', { msg: 'Your password has been changed, however we were unable to send you a confirmation email. We will be looking into it shortly.' });
         return err;
       });
@@ -539,24 +505,7 @@ exports.postForgot = (req, res, next) => {
         req.flash('info', { msg: `An e-mail has been sent to ${user.email} with further instructions.` });
       })
       .catch((err) => {
-        if (err.message === 'self signed certificate in certificate chain') {
-          console.log('WARNING: Self signed certificate in certificate chain. Retrying with the self signed certificate. Use a valid certificate if in production.');
-          transporter = nodemailer.createTransport({
-            service: 'SendGrid',
-            auth: {
-              user: process.env.SENDGRID_USER,
-              pass: process.env.SENDGRID_PASSWORD
-            },
-            tls: {
-              rejectUnauthorized: false
-            }
-          });
-          return transporter.sendMail(mailOptions)
-            .then(() => {
-              req.flash('info', { msg: `An e-mail has been sent to ${user.email} with further instructions.` });
-            });
-        }
-        console.log('ERROR: Could not send forgot password email after security downgrade.\n', err);
+        console.log('ERROR: Could not send forgot password email.\n', err);
         req.flash('errors', { msg: 'Error sending the password reset message. Please try again shortly.' });
         return err;
       });


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The application was configured to fallback to an insecure TLS configuration (`rejectUnauthorized: false`) in its `nodemailer` transporters when sending emails (such as password resets and contact forms) if the initial connection failed due to a certificate error (e.g., self-signed certificates). 
🎯 **Impact**: This insecure configuration allows an attacker to perform a Man-In-The-Middle (MITM) attack, intercepting or modifying the sensitive email contents (like password reset tokens) in transit.
🔧 **Fix**: Removed the insecure `rejectUnauthorized: false` fallback configuration and simplified the Promise catch blocks to cleanly handle and log legitimate email sending errors without downgrading security.
✅ **Verification**: Run `npm test` and `npm run lint`. The application should no longer attempt a second, insecure connection when email delivery fails due to certificate issues.

---
*PR created automatically by Jules for task [251535762072567083](https://jules.google.com/task/251535762072567083) started by @mbarbine*