### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect bypass in session returnTo

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,7 @@
 **Vulnerability:** Missing rate limit on `/forgot` endpoint allowing potential DoS and email flooding.
 **Learning:** Legacy endpoints sending emails or SMS must be explicitly protected by rate limiters to prevent abuse.
 **Prevention:** Always apply `express-rate-limit` (or similar) to any route that triggers external side-effects like email delivery.
+## 2026-03-22 - [HIGH] Open Redirect Bypass via Backslash in session returnTo
+**Vulnerability:** The application attempted to prevent open redirects by verifying that `req.session.returnTo` matched `/^\/[^\/]/`. However, an attacker could supply a path like `/\evil.com`, which Express and browsers treat as `//evil.com`, leading to an open redirect.
+**Learning:** Checking that a URL path starts with a single slash and is not followed by another forward slash is insufficient protection for open redirects. Backslashes (`\`) can act similarly to forward slashes in URL parsing contexts, allowing for protocol-relative bypasses.
+**Prevention:** Update regex validation for absolute local paths to also reject backslashes. For example, use `/^\/[^\/\\]/` to enforce that the path begins strictly with `/` followed by any character except `/` or `\`.

--- a/app.js
+++ b/app.js
@@ -134,7 +134,7 @@ app.use((req, res, next) => {
   // Prevent open redirect
   const { returnTo } = req.session;
   if (returnTo && returnTo !== '/') {
-    if (!returnTo.match(/^\/[^\/]/)) {
+    if (!returnTo.match(/^\/[^\/\\]/)) {
       req.session.returnTo = '/';
     }
   }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Open Redirect bypass in `req.session.returnTo`
🎯 Impact: Attackers could supply a URL like `/\malicious.com`, bypassing the previous open redirect check (which only checked for `//`). Express and modern browsers treat `/\` as a protocol-relative redirect to `//malicious.com`, redirecting users after login to an external site.
🔧 Fix: Updated the regex validation in `app.js` to strictly match paths starting with a single forward slash and no backslashes (`[^\/\\]`).
✅ Verification: Review the updated regex `^\/[^\/\\]/` logic. Evaluated via direct testing scripts that prove `/\malicious.com` fails the new regex check, while `/valid/path` passes.

---
*PR created automatically by Jules for task [600954817685159721](https://jules.google.com/task/600954817685159721) started by @mbarbine*