### PR TITLE
🎨 Palette: Add alt attributes to API view images

### DIFF
--- a/views/api/github.pug
+++ b/views/api/github.pug
@@ -22,7 +22,7 @@ block content
     .card-body.text-dark.bg-white
       .row
         .col-4
-          img.rounded.img-fluid(src='https://github.githubassets.com/images/modules/logos_page/Octocat.png')
+          img.rounded.img-fluid(src='https://github.githubassets.com/images/modules/logos_page/Octocat.png', alt='Octocat logo')
         .col-8
           h4
             a(href=repo.html_url) #{repo.name}

--- a/views/api/steam.pug
+++ b/views/api/steam.pug
@@ -19,7 +19,7 @@ block content
   h3 Profile Information
   .row
     .col-sm-2
-      img(src=playerSummary.avatarfull, width='92', height='92')
+      img(src=playerSummary.avatarfull, width='92', height='92', alt='Steam profile picture')
     .col-sm-8
       span.lead #{playerSummary.personaname}
       div Account since: #{new Date(playerSummary.timecreated * 1000)}
@@ -45,4 +45,4 @@ block content
     br
     for game in ownedGames.games
       a(href='https://store.steampowered.com/app/' + game.appid)
-        img.thumbnail(src='https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/' + game.appid + '/' + game.img_logo_url + '.jpg' width=92)
+        img.thumbnail(src='https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/' + game.appid + '/' + game.img_logo_url + '.jpg', width=92, alt='Game logo')

--- a/views/api/twitch.pug
+++ b/views/api/twitch.pug
@@ -14,7 +14,7 @@ block content
   h3 Your Public Profile Information
   .row
     .col-sm-2
-      img(src=yourTwitchUserData.profile_image_url, width='92', height='92')
+      img(src=yourTwitchUserData.profile_image_url, width='92', height='92', alt='Your Twitch profile picture')
     .col-sm-8
       span.lead Name: #{yourTwitchUserData.display_name}
       div Twitch ID: #{yourTwitchUserData.login}
@@ -28,7 +28,7 @@ block content
   h3 Public Profile Information - Example
   .row
     .col-sm-2
-      img(src=otherTwitchUserData.profile_image_url, width='92', height='92')
+      img(src=otherTwitchUserData.profile_image_url, width='92', height='92', alt='Other Twitch profile picture')
     .col-sm-8
       span.lead Name: #{otherTwitchUserData.display_name}
       div Twitch ID: #{otherTwitchUserData.login}


### PR DESCRIPTION
💡 What: Added missing `alt` attributes to image elements in `views/api/github.pug`, `views/api/twitch.pug`, and `views/api/steam.pug`.
🎯 Why: To improve screen reader accessibility by providing descriptive text for images (e.g., logos, profile pictures) and preventing screen readers from reading out long, unhelpful raw image URLs.
♿ Accessibility: Improved WCAG compliance by ensuring non-text content has a text alternative.

---
*PR created automatically by Jules for task [12992355063177749515](https://jules.google.com/task/12992355063177749515) started by @mbarbine*