### PR TITLE
🎨 Palette: Add accessible label and alt attributes to Twitter API view

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,6 @@
 ## 2026-03-20 - Redundant Alt Text on Decorative Icons
 **Learning:** Adding descriptive `alt` text to images that sit right next to their textual equivalent (e.g., `alt='GitHub Logo' | GitHub`) can cause screen readers to announce the information redundantly. For decorative images next to text, an empty string `alt=""` is often preferred to make the screen reader skip the image entirely. However, adding descriptive `alt` text is still vastly superior to omitting the attribute entirely, which causes the screen reader to read the raw image URL.
 **Action:** When adding `alt` attributes to images that are purely decorative or immediately followed by the exact same text, consider using an empty string `alt=""` to avoid redundant announcements.
+## 2026-03-26 - Missing form labels in Twitter API view
+**Learning:** Found an accessibility issue pattern where inputs in views (like the Compose Tweet field) were completely lacking labels, forcing screen readers to guess their purpose.
+**Action:** Always verify that input fields have either a visible label or a screen-reader-only (`.sr-only`) label connected via `for`/`id` attributes.

--- a/views/api/twitter.pug
+++ b/views/api/twitter.pug
@@ -24,7 +24,8 @@ block content
     form(role='form', method='POST')
       input(type='hidden', name='_csrf', value=_csrf)
       .form-group
-        input.form-control(type='text', name='tweet', autofocus)
+        label.sr-only(for='tweet') Compose new Tweet
+        input.form-control(type='text', name='tweet', id='tweet', autofocus)
         p.form-text This new Tweet will be posted on your Twitter profile.
       button.btn.btn-primary(type='submit')
         i.fab.fa-twitter.fa-sm
@@ -45,7 +46,7 @@ block content
       li.media
         a.float-left(href='#')
           - var image = tweet.user.profile_image_url.replace('_normal', '');
-          img.media-object(src=image, style='width: 64px; height: 64px;')
+          img.media-object(src=image, style='width: 64px; height: 64px;', alt='')
         .media-body
           strong.media-heading #{tweet.user.name}
           span.text-muted  @#{tweet.user.screen_name}


### PR DESCRIPTION
💡 What:
- Added a screen-reader-only (`sr-only`) label connected via `for` and `id` to the "Compose new Tweet" input.
- Added an empty `alt=""` attribute to the decorative profile images in the tweet list.

🎯 Why:
- The "Compose new Tweet" input previously lacked an accessible name, making it difficult for screen reader users to identify its purpose.
- The profile images in the tweet list are immediately followed by the user's name (in `strong.media-heading`). Leaving the `alt` attribute missing causes screen readers to read the raw image URL. Providing an empty `alt=""` correctly instructs screen readers to skip the redundant decorative image.

📸 Before/After:
No visible changes for sighted users, as the label uses the `.sr-only` class.

♿ Accessibility:
- Forms now have properly associated labels.
- Reduced noise for screen reader users navigating the tweet feed by silencing raw image URLs.

---
*PR created automatically by Jules for task [11493247322026812137](https://jules.google.com/task/11493247322026812137) started by @mbarbine*