### PR TITLE
🎨 Palette: Remove redundant alt text from API Sandbox logos

### DIFF
--- a/views/api/index.pug
+++ b/views/api/index.pug
@@ -9,143 +9,143 @@ block content
       a(href='/api/github', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/2AaBlpf.png', height=40, alt='GitHub')
+            img(src='https://i.imgur.com/2AaBlpf.png', height=40, alt='')
             |  GitHub
     .col-md-4
       a(href='/api/twitter', style='color: #fff')
         .card(style='background-color: #00abf0').mb-3
           .card-body
-            img(src='https://i.imgur.com/EYA2FO1.png', height=40, alt='Twitter')
+            img(src='https://i.imgur.com/EYA2FO1.png', height=40, alt='')
             |  Twitter
     .col-md-4
       a(href='/api/facebook', style='color: #fff')
         .card(style='background-color: #3b5998').mb-3
           .card-body
-            img(src='https://i.imgur.com/jiztYCH.png', height=40, alt='Facebook')
+            img(src='https://i.imgur.com/jiztYCH.png', height=40, alt='')
             |  Facebook
     .col-md-4
       a(href='/api/foursquare', style='color: #fff')
         .card(style='background-color: #1cafec').mb-3
           .card-body
-            img(src='https://i.imgur.com/PixH9li.png', height=40, alt='Foursquare')
+            img(src='https://i.imgur.com/PixH9li.png', height=40, alt='')
             |  Foursquare
     .col-md-4
       a(href='/api/instagram', style='color: #fff')
         .card(style='background-color: #947563').mb-3
           .card-body
-            img(src='https://i.imgur.com/aRc6LUJ.png', height=40, alt='Instagram')
+            img(src='https://i.imgur.com/aRc6LUJ.png', height=40, alt='')
             |  Instagram
     .col-md-4
       a(href='/api/lastfm', style='color: #fff')
         .card(style='background-color: #d21309').mb-3
           .card-body
-            img(src='https://i.imgur.com/KfZY876.png', height=40, alt='Last.fm')
+            img(src='https://i.imgur.com/KfZY876.png', height=40, alt='')
             |  Last.fm
     .col-md-4
       a(href='/api/nyt', style='color: #fff')
         .card(style='background-color: #454442').mb-3
           .card-body
-            img(src='https://i.imgur.com/e3sjmYj.png', height=40, alt='New York Times')
+            img(src='https://i.imgur.com/e3sjmYj.png', height=40, alt='')
             |  New York Times
     .col-md-4
       a(href='/api/steam', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/6WXcNeg.png', height=40, alt='Steam')
+            img(src='https://i.imgur.com/6WXcNeg.png', height=40, alt='')
             |  Steam
     .col-md-4
       a(href='/api/twitch', style='color: #fff')
         .card(style='background-color: #6441a5').mb-3
           .card-body
-            img(src='https://i.imgur.com/dWEkSRX.png', height=40, alt='Twitch')
+            img(src='https://i.imgur.com/dWEkSRX.png', height=40, alt='')
             |  Twitch
     .col-md-4
       a(href='/api/stripe', style='color: #fff')
         .card(style='background-color: #3da8e5').mb-3
           .card-body
-            img(src='https://i.imgur.com/w3s2RvW.png', height=40, alt='Stripe')
+            img(src='https://i.imgur.com/w3s2RvW.png', height=40, alt='')
             |  Stripe
     .col-md-4
       a(href='/api/paypal', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNc0iaX.png', height=40, alt='PayPal')
+            img(src='https://i.imgur.com/JNc0iaX.png', height=40, alt='')
             |  PayPal
     .col-md-4
       a(href='/api/quickbooks', style='color: #fff')
         .card(style='background-color: #0077C5').mb-3
           .card-body
-            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='QuickBooks')
+            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='')
             |  QuickBooks
     .col-md-4
       a(href='/api/twilio', style='color: #fff')
         .card(style='background-color: #fd0404').mb-3
           .card-body
-            img(src='https://i.imgur.com/mEUd6zM.png', height=40, alt='Twilio')
+            img(src='https://i.imgur.com/mEUd6zM.png', height=40, alt='')
             |  Twilio
     .col-md-4
       a(href='/api/tumblr', style='color: #fff')
         .card(style='background-color: #304e6c').mb-3
           .card-body
-            img(src='https://i.imgur.com/rZGQShS.png', height=40, alt='Tumblr')
+            img(src='https://i.imgur.com/rZGQShS.png', height=40, alt='')
             |  Tumblr
     .col-md-4
       a(href='/api/scraping', style='color: #fff')
         .card(style='background-color: #ff6500').mb-3
           .card-body
-            img(src='https://i.imgur.com/RGCVvyR.png', height=40, alt='Web Scraping')
+            img(src='https://i.imgur.com/RGCVvyR.png', height=40, alt='')
             |  Web Scraping
     .col-md-4
       a(href='/api/clockwork', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='Clockwork SMS')
+            img(src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='')
             |  Clockwork SMS
     .col-md-4
       a(href='/api/lob', style='color: #fff')
         .card(style='background-color: #176992').mb-3
           .card-body
-            img(src='https://i.imgur.com/bmgfsSg.png', height=40, alt='Lob')
+            img(src='https://i.imgur.com/bmgfsSg.png', height=40, alt='')
             |  Lob
     .col-md-4
       a(href='/api/upload', style='color: #1565c0')
         .card(style='background-color: #fff').mb-3
           .card-body
-            img(src='https://i.imgur.com/UPTzIdC.png', height=40, alt='File Upload')
+            img(src='https://i.imgur.com/UPTzIdC.png', height=40, alt='')
             |  File Upload
     .col-md-4
       a(href='/api/pinterest', style='color: #fff')
         .card(style='background-color: #bd081c').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNNRQSm.png', height=40, alt='Pinterest')
+            img(src='https://i.imgur.com/JNNRQSm.png', height=40, alt='')
             |  Pinterest
     .col-md-4
       a(href='/api/google-maps', style='color: #fff')
         .card(style='background-color: #20a360').mb-3
           .card-body
-            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='Google Maps')
+            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='')
             |  Google Maps
     .col-md-4
       a(href='/api/here-maps', style='color: #0f1621')
         .card(style='background-color: #d1f6f3').mb-3
           .card-body
-            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='HERE Maps')
+            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='')
             |  HERE Maps
     .col-md-4
       a(href='/api/chart', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='Chart.js + Alpha Vantage')
+            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='')
             |  Chart.js + Alpha Vantage
     .col-md-4
       a(href='/api/google/drive', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='Google Drive')
+            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='')
             |  Google Drive
     .col-md-4
       a(href='/api/google/sheets', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='Google Sheets')
+            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='')
             |  Google Sheets


### PR DESCRIPTION
💡 **What:** Replaced the explicit `alt` text attributes on the 24 API Sandbox logos in `views/api/index.pug` with empty strings (`alt=''`).

🎯 **Why:** The logos are immediately followed by identical visible text (e.g., an image of the GitHub logo next to the text "GitHub"). When the image also has `alt='GitHub'`, screen readers redundantly announce the text twice (e.g., "GitHub, GitHub"). Using an empty `alt` attribute correctly marks the image as decorative or redundant, preventing the double announcement and making the interface more pleasant for users of assistive technologies.

📸 **Before/After:** The visual layout is completely unchanged. Only the semantic HTML structure provided to screen readers has been optimized.

♿ **Accessibility:** Prevents redundant and verbose screen reader announcements for decorative/accompanied images in the API Sandbox grid, adhering to best practices for accessible image descriptions.

---
*PR created automatically by Jules for task [1900334767963767520](https://jules.google.com/task/1900334767963767520) started by @mbarbine*