### PR TITLE
🎨 Palette: Add screen reader label to Clockwork SMS input

### DIFF
--- a/views/api/clockwork.pug
+++ b/views/api/clockwork.pug
@@ -20,7 +20,8 @@ block content
       form(role='form', method='POST')
         input(type='hidden', name='_csrf', value=_csrf)
         .form-group
+          label.visually-hidden(for='telephone') Phone Number
           .input-group
-            input.form-control(type='text', name='telephone', placeholder='Phone Number (international format)')
+            input.form-control(type='text', name='telephone', id='telephone', placeholder='Phone Number (international format)')
             span.input-group-btn
               button.btn.btn-success(type='submit') Send


### PR DESCRIPTION
💡 What: Added an explicit `<label>` with `for` attribute and matched it to an `id` on the `<input>` for the phone number field.
🎯 Why: Without a mapped label, screen readers cannot reliably announce the purpose of the input field to users, relying only on placeholder text which is often insufficient or unsupported by all assistive tech.
📸 Before/After: Not applicable as it is visually hidden.
♿ Accessibility: Ensures the "Phone Number (international format)" input is correctly announced by screen readers, solving the issue of inputs missing explicit labels in the codebase.

---
*PR created automatically by Jules for task [16995211699086101914](https://jules.google.com/task/16995211699086101914) started by @mbarbine*