### PR TITLE
🎨 Palette: Add context-aware alt text to API images

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,6 @@
 ## 2026-03-26 - Missing form labels in Twitter API view
 **Learning:** Found an accessibility issue pattern where inputs in views (like the Compose Tweet field) were completely lacking labels, forcing screen readers to guess their purpose.
 **Action:** Always verify that input fields have either a visible label or a screen-reader-only (`.sr-only`) label connected via `for`/`id` attributes.
+## 2026-03-26 - Context-Aware Alt Text in Pug Templates
+**Learning:** Many API view templates iteratively render dynamic images (e.g., `lastfm.pug` showing Top Albums) using `img(src=...)` with no `alt` text. This leaves screen readers totally blind to the images' content.
+**Action:** When adding missing `alt` attributes to dynamic images in Pug templates, prefer context-aware descriptions that leverage existing loop or context variables (e.g., `alt=artist.name + ' image'`) over generic strings.

--- a/views/api/foursquare.pug
+++ b/views/api/foursquare.pug
@@ -34,7 +34,7 @@ block content
   br
   h3.text-primary Venue Detail
   p
-    img(src=venueDetail.venue.photos.groups[0].items[0].prefix + '150x150' + venueDetail.venue.photos.groups[0].items[0].suffix)
+    img(src=venueDetail.venue.photos.groups[0].items[0].prefix + '150x150' + venueDetail.venue.photos.groups[0].items[0].suffix, alt=venueDetail.venue.name + ' photo')
 
   .badge.badge-primary #{venueDetail.venue.name} (#{venueDetail.venue.categories[0].shortName})
   .badge.badge-success #{venueDetail.venue.location.address}, #{venueDetail.venue.location.city}, #{venueDetail.venue.location.state}

--- a/views/api/google-drive.pug
+++ b/views/api/google-drive.pug
@@ -21,7 +21,7 @@ block content
       | The list of files at the root of your Google Drive
     for file in files
       li
-        img(src=file.iconLink)
+        img(src=file.iconLink, alt=file.name + ' icon')
         | 
         a(href=file.webViewLink, target="_blank")
          =file.name

--- a/views/api/here-maps.pug
+++ b/views/api/here-maps.pug
@@ -20,7 +20,7 @@ block content
   div(style='display:flex; justify-content: center;')
     | This non-interactive map renders without the use of any client-side scripts:
   div(style='display:flex; justify-content: center;')
-    img(src= imageMapURL)
+    img(src= imageMapURL, alt='HERE Maps Image Map')
 
   br
   .pb-2.mt-2.mt-4.border-top

--- a/views/api/instagram.pug
+++ b/views/api/instagram.pug
@@ -26,4 +26,4 @@ block content
     for image in myRecentMedia
       .col-xs-3
         a.thumbnail(href=image.link)
-          img(src=image.images.standard_resolution.url, height='320px')
+          img(src=image.images.standard_resolution.url, height='320px', alt='Instagram media from your feed')

--- a/views/api/lastfm.pug
+++ b/views/api/lastfm.pug
@@ -21,7 +21,7 @@ block content
   else
     h3= artist.name
     if artist.image
-      img.thumbnail(src='' + artist.image)
+      img.thumbnail(src='' + artist.image, alt=artist.name + ' image')
 
     h3 Tags
     for tag in artist.tags
@@ -38,7 +38,7 @@ block content
 
     h3 Top Albums
     for album in artist.topAlbums
-      img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150)
+      img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150, alt=album.name + ' album cover')
       | &nbsp;
 
     h3 Top Tracks


### PR DESCRIPTION
💡 What: Added contextual `alt` attributes to dynamic image tags across multiple API views (Last.fm, Instagram, Google Drive, Here Maps, Foursquare).
🎯 Why: Images that are missing `alt` attributes are skipped or read poorly by screen readers. Providing specific, context-aware alt text describing the image contents improves accessibility.
♿ Accessibility: Added `alt` text.

---
*PR created automatically by Jules for task [5216559286951874869](https://jules.google.com/task/5216559286951874869) started by @mbarbine*