### PR TITLE
⚡ Bolt: Add lazy loading to API index grid images below the fold

### DIFF
--- a/views/api/index.pug
+++ b/views/api/index.pug
@@ -59,93 +59,94 @@ block content
           .card-body
             img(src='https://i.imgur.com/dWEkSRX.png', height=40, alt='')
             |  Twitch
+    // ⚡ Bolt: Added loading="lazy" to images below the fold to defer loading, reduce bandwidth, and improve initial page load time.
     .col-md-4
       a(href='/api/stripe', style='color: #fff')
         .card(style='background-color: #3da8e5').mb-3
           .card-body
-            img(src='https://i.imgur.com/w3s2RvW.png', height=40, alt='')
+            img(loading="lazy" src='https://i.imgur.com/w3s2RvW.png', height=40, alt='')
             |  Stripe
     .col-md-4
       a(href='/api/paypal', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNc0iaX.png', height=40, alt='')
+            img(loading="lazy" src='https://i.imgur.com/JNc0iaX.png', height=40, alt='')
             |  PayPal
     .col-md-4
       a(href='/api/quickbooks', style='color: #fff')
         .card(style='background-color: #0077C5').mb-3
           .card-body
-            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='')
+            img(loading="lazy" src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='')
             |  QuickBooks
     .col-md-4
       a(href='/api/twilio', style='color: #fff')
         .card(style='background-color: #fd0404').mb-3
           .card-body
-            img(src='https://i.imgur.com/mEUd6zM.png', height=40, alt='')
+            img(loading="lazy" src='https://i.imgur.com/mEUd6zM.png', height=40, alt='')
             |  Twilio
     .col-md-4
       a(href='/api/tumblr', style='color: #fff')
         .card(style='background-color: #304e6c').mb-3
           .card-body
-            img(src='https://i.imgur.com/rZGQShS.png', height=40, alt='')
+            img(loading="lazy" src='https://i.imgur.com/rZGQShS.png', height=40, alt='')
             |  Tumblr
     .col-md-4
       a(href='/api/scraping', style='color: #fff')
         .card(style='background-color: #ff6500').mb-3
           .card-body
-            img(src='https://i.imgur.com/RGCVvyR.png', height=40, alt='')
+            img(loading="lazy" src='https://i.imgur.com/RGCVvyR.png', height=40, alt='')
             |  Web Scraping
     .col-md-4
       a(href='/api/clockwork', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='')
+            img(loading="lazy" src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='')
             |  Clockwork SMS
     .col-md-4
       a(href='/api/lob', style='color: #fff')
         .card(style='background-color: #176992').mb-3
           .card-body
-            img(src='https://i.imgur.com/bmgfsSg.png', height=40, alt='')
+            img(loading="lazy" src='https://i.imgur.com/bmgfsSg.png', height=40, alt='')
             |  Lob
     .col-md-4
       a(href='/api/upload', style='color: #1565c0')
         .card(style='background-color: #fff').mb-3
           .card-body
-            img(src='https://i.imgur.com/UPTzIdC.png', height=40, alt='')
+            img(loading="lazy" src='https://i.imgur.com/UPTzIdC.png', height=40, alt='')
             |  File Upload
     .col-md-4
       a(href='/api/pinterest', style='color: #fff')
         .card(style='background-color: #bd081c').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNNRQSm.png', height=40, alt='')
+            img(loading="lazy" src='https://i.imgur.com/JNNRQSm.png', height=40, alt='')
             |  Pinterest
     .col-md-4
       a(href='/api/google-maps', style='color: #fff')
         .card(style='background-color: #20a360').mb-3
           .card-body
-            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='')
+            img(loading="lazy" src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='')
             |  Google Maps
     .col-md-4
       a(href='/api/here-maps', style='color: #0f1621')
         .card(style='background-color: #d1f6f3').mb-3
           .card-body
-            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='')
+            img(loading="lazy" src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='')
             |  HERE Maps
     .col-md-4
       a(href='/api/chart', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='')
+            img(loading="lazy" src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='')
             |  Chart.js + Alpha Vantage
     .col-md-4
       a(href='/api/google/drive', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='')
+            img(loading="lazy" src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='')
             |  Google Drive
     .col-md-4
       a(href='/api/google/sheets', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='')
+            img(loading="lazy" src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='')
             |  Google Sheets


### PR DESCRIPTION
💡 What: Added the `loading="lazy"` attribute to grid image tags in `views/api/index.pug` that appear "below the fold".
🎯 Why: To prevent the browser from eagerly downloading off-screen logo images on the API Sandbox index page, which wastes bandwidth and slows down the initial page render.
📊 Impact: Defers the loading of 15+ images, reducing the initial payload size and significantly improving page load time.
🔬 Measurement: Can be verified using browser developer tools (Network tab) to confirm that images below the fold are not downloaded until scrolled into view.

---
*PR created automatically by Jules for task [870985999441947171](https://jules.google.com/task/870985999441947171) started by @mbarbine*