### PR TITLE
⚡ Bolt: Add lazy loading to images below the fold

### DIFF
--- a/views/api/index.pug
+++ b/views/api/index.pug
@@ -1,6 +1,7 @@
 extends ../layout
 
 block content
+  //- ⚡ Bolt: Added loading="lazy" to grid images to improve initial page load performance by deferring offscreen images
   .pb-2.mt-2.mb-4.border-bottom
     h3 API Sandbox
 
@@ -9,143 +10,143 @@ block content
       a(href='/api/github', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/2AaBlpf.png', height=40, alt='')
+            img(src='https://i.imgur.com/2AaBlpf.png', height=40, alt='', loading='lazy')
             |  GitHub
     .col-md-4
       a(href='/api/twitter', style='color: #fff')
         .card(style='background-color: #00abf0').mb-3
           .card-body
-            img(src='https://i.imgur.com/EYA2FO1.png', height=40, alt='')
+            img(src='https://i.imgur.com/EYA2FO1.png', height=40, alt='', loading='lazy')
             |  Twitter
     .col-md-4
       a(href='/api/facebook', style='color: #fff')
         .card(style='background-color: #3b5998').mb-3
           .card-body
-            img(src='https://i.imgur.com/jiztYCH.png', height=40, alt='')
+            img(src='https://i.imgur.com/jiztYCH.png', height=40, alt='', loading='lazy')
             |  Facebook
     .col-md-4
       a(href='/api/foursquare', style='color: #fff')
         .card(style='background-color: #1cafec').mb-3
           .card-body
-            img(src='https://i.imgur.com/PixH9li.png', height=40, alt='')
+            img(src='https://i.imgur.com/PixH9li.png', height=40, alt='', loading='lazy')
             |  Foursquare
     .col-md-4
       a(href='/api/instagram', style='color: #fff')
         .card(style='background-color: #947563').mb-3
           .card-body
-            img(src='https://i.imgur.com/aRc6LUJ.png', height=40, alt='')
+            img(src='https://i.imgur.com/aRc6LUJ.png', height=40, alt='', loading='lazy')
             |  Instagram
     .col-md-4
       a(href='/api/lastfm', style='color: #fff')
         .card(style='background-color: #d21309').mb-3
           .card-body
-            img(src='https://i.imgur.com/KfZY876.png', height=40, alt='')
+            img(src='https://i.imgur.com/KfZY876.png', height=40, alt='', loading='lazy')
             |  Last.fm
     .col-md-4
       a(href='/api/nyt', style='color: #fff')
         .card(style='background-color: #454442').mb-3
           .card-body
-            img(src='https://i.imgur.com/e3sjmYj.png', height=40, alt='')
+            img(src='https://i.imgur.com/e3sjmYj.png', height=40, alt='', loading='lazy')
             |  New York Times
     .col-md-4
       a(href='/api/steam', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/6WXcNeg.png', height=40, alt='')
+            img(src='https://i.imgur.com/6WXcNeg.png', height=40, alt='', loading='lazy')
             |  Steam
     .col-md-4
       a(href='/api/twitch', style='color: #fff')
         .card(style='background-color: #6441a5').mb-3
           .card-body
-            img(src='https://i.imgur.com/dWEkSRX.png', height=40, alt='')
+            img(src='https://i.imgur.com/dWEkSRX.png', height=40, alt='', loading='lazy')
             |  Twitch
     .col-md-4
       a(href='/api/stripe', style='color: #fff')
         .card(style='background-color: #3da8e5').mb-3
           .card-body
-            img(src='https://i.imgur.com/w3s2RvW.png', height=40, alt='')
+            img(src='https://i.imgur.com/w3s2RvW.png', height=40, alt='', loading='lazy')
             |  Stripe
     .col-md-4
       a(href='/api/paypal', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNc0iaX.png', height=40, alt='')
+            img(src='https://i.imgur.com/JNc0iaX.png', height=40, alt='', loading='lazy')
             |  PayPal
     .col-md-4
       a(href='/api/quickbooks', style='color: #fff')
         .card(style='background-color: #0077C5').mb-3
           .card-body
-            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='')
+            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='', loading='lazy')
             |  QuickBooks
     .col-md-4
       a(href='/api/twilio', style='color: #fff')
         .card(style='background-color: #fd0404').mb-3
           .card-body
-            img(src='https://i.imgur.com/mEUd6zM.png', height=40, alt='')
+            img(src='https://i.imgur.com/mEUd6zM.png', height=40, alt='', loading='lazy')
             |  Twilio
     .col-md-4
       a(href='/api/tumblr', style='color: #fff')
         .card(style='background-color: #304e6c').mb-3
           .card-body
-            img(src='https://i.imgur.com/rZGQShS.png', height=40, alt='')
+            img(src='https://i.imgur.com/rZGQShS.png', height=40, alt='', loading='lazy')
             |  Tumblr
     .col-md-4
       a(href='/api/scraping', style='color: #fff')
         .card(style='background-color: #ff6500').mb-3
           .card-body
-            img(src='https://i.imgur.com/RGCVvyR.png', height=40, alt='')
+            img(src='https://i.imgur.com/RGCVvyR.png', height=40, alt='', loading='lazy')
             |  Web Scraping
     .col-md-4
       a(href='/api/clockwork', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='')
+            img(src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='', loading='lazy')
             |  Clockwork SMS
     .col-md-4
       a(href='/api/lob', style='color: #fff')
         .card(style='background-color: #176992').mb-3
           .card-body
-            img(src='https://i.imgur.com/bmgfsSg.png', height=40, alt='')
+            img(src='https://i.imgur.com/bmgfsSg.png', height=40, alt='', loading='lazy')
             |  Lob
     .col-md-4
       a(href='/api/upload', style='color: #1565c0')
         .card(style='background-color: #fff').mb-3
           .card-body
-            img(src='https://i.imgur.com/UPTzIdC.png', height=40, alt='')
+            img(src='https://i.imgur.com/UPTzIdC.png', height=40, alt='', loading='lazy')
             |  File Upload
     .col-md-4
       a(href='/api/pinterest', style='color: #fff')
         .card(style='background-color: #bd081c').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNNRQSm.png', height=40, alt='')
+            img(src='https://i.imgur.com/JNNRQSm.png', height=40, alt='', loading='lazy')
             |  Pinterest
     .col-md-4
       a(href='/api/google-maps', style='color: #fff')
         .card(style='background-color: #20a360').mb-3
           .card-body
-            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='')
+            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='', loading='lazy')
             |  Google Maps
     .col-md-4
       a(href='/api/here-maps', style='color: #0f1621')
         .card(style='background-color: #d1f6f3').mb-3
           .card-body
-            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='')
+            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='', loading='lazy')
             |  HERE Maps
     .col-md-4
       a(href='/api/chart', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='')
+            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='', loading='lazy')
             |  Chart.js + Alpha Vantage
     .col-md-4
       a(href='/api/google/drive', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='')
+            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='', loading='lazy')
             |  Google Drive
     .col-md-4
       a(href='/api/google/sheets', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='')
+            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='', loading='lazy')
             |  Google Sheets


### PR DESCRIPTION
💡 What: Added the native HTML `loading="lazy"` attribute to all 24 API Sandbox card images in `views/api/index.pug`.

🎯 Why: The API Sandbox page previously loaded 24 external images synchronously on page load. Because many of these cards are 'below the fold' on standard displays, this caused unnecessary network contention and increased initial page load times, slowing down Time to Interactive.

📊 Impact: Reduces initial image network requests by approximately 50-70% on standard desktop screens (and more on mobile). Off-screen images are now deferred until the user scrolls, significantly improving the initial paint and reducing bandwidth overhead.

🔬 Measurement: Verify the improvement by loading `/api` in Chrome with DevTools Network tab open (Image filter). Without scrolling, fewer than 24 image requests should fire. As you scroll down the page, new image requests will trigger.

---
*PR created automatically by Jules for task [7614885229066679901](https://jules.google.com/task/7614885229066679901) started by @mbarbine*