### PR TITLE
🎨 Palette: Add context-aware alt text to API view images

### DIFF
--- a/views/api/facebook.pug
+++ b/views/api/facebook.pug
@@ -19,7 +19,7 @@ block content
   h3
     i.far.fa-user.fa-sm
     |  My Profile
-  img.thumbnail(src=`https://graph.facebook.com/${profile.id}/picture?type=large`, width='90', height='90')
+  img.thumbnail(src=`https://graph.facebook.com/${profile.id}/picture?type=large`, width='90', height='90', alt=profile.name + ' profile picture')
   h4= profile.name
   h6 First Name: #{profile.first_name}
   h6 Last Name: #{profile.last_name}

--- a/views/api/foursquare.pug
+++ b/views/api/foursquare.pug
@@ -34,7 +34,7 @@ block content
   br
   h3.text-primary Venue Detail
   p
-    img(src=venueDetail.venue.photos.groups[0].items[0].prefix + '150x150' + venueDetail.venue.photos.groups[0].items[0].suffix)
+    img(src=venueDetail.venue.photos.groups[0].items[0].prefix + '150x150' + venueDetail.venue.photos.groups[0].items[0].suffix, alt=venueDetail.venue.name + ' photo')
 
   .badge.badge-primary #{venueDetail.venue.name} (#{venueDetail.venue.categories[0].shortName})
   .badge.badge-success #{venueDetail.venue.location.address}, #{venueDetail.venue.location.city}, #{venueDetail.venue.location.state}

--- a/views/api/google-drive.pug
+++ b/views/api/google-drive.pug
@@ -21,7 +21,7 @@ block content
       | The list of files at the root of your Google Drive
     for file in files
       li
-        img(src=file.iconLink)
+        img(src=file.iconLink, alt=file.name + ' icon')
         | 
         a(href=file.webViewLink, target="_blank")
          =file.name

--- a/views/api/here-maps.pug
+++ b/views/api/here-maps.pug
@@ -20,7 +20,7 @@ block content
   div(style='display:flex; justify-content: center;')
     | This non-interactive map renders without the use of any client-side scripts:
   div(style='display:flex; justify-content: center;')
-    img(src= imageMapURL)
+    img(src= imageMapURL, alt='HERE map showing location')
 
   br
   .pb-2.mt-2.mt-4.border-top

--- a/views/api/instagram.pug
+++ b/views/api/instagram.pug
@@ -26,4 +26,4 @@ block content
     for image in myRecentMedia
       .col-xs-3
         a.thumbnail(href=image.link)
-          img(src=image.images.standard_resolution.url, height='320px')
+          img(src=image.images.standard_resolution.url, height='320px', alt='Instagram image')

--- a/views/api/lastfm.pug
+++ b/views/api/lastfm.pug
@@ -21,7 +21,7 @@ block content
   else
     h3= artist.name
     if artist.image
-      img.thumbnail(src='' + artist.image)
+      img.thumbnail(src='' + artist.image, alt=artist.name + ' image')
 
     h3 Tags
     for tag in artist.tags
@@ -38,7 +38,7 @@ block content
 
     h3 Top Albums
     for album in artist.topAlbums
-      img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150)
+      img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150, alt=artist.name + ' album cover')
       | &nbsp;
 
     h3 Top Tracks

--- a/views/api/tumblr.pug
+++ b/views/api/tumblr.pug
@@ -23,4 +23,4 @@ block content
     | #{blog.posts} posts
   h4 Latest Photo Post
   for photo in photoset
-    img.item(src=photo.original_size.url)
+    img.item(src=photo.original_size.url, alt=blog.name + ' photo')


### PR DESCRIPTION
💡 **What**: Added context-aware `alt` attributes to various `img` tags across multiple API view templates (`foursquare`, `tumblr`, `google-drive`, `here-maps`, `facebook`, `instagram`, `lastfm`).

🎯 **Why**: To improve accessibility for screen readers. Previously, these images lacked `alt` text, which meant screen readers would either skip them entirely or read their unhelpful image URLs. By adding context-aware descriptions (e.g., "Profile picture", "Test Venue photo"), the UI becomes significantly more accessible and intuitive for visually impaired users.

📸 **Before/After**: Visually, the UI remains identical, but the underlying DOM now includes necessary accessibility markers. Tested with Playwright standalone rendering.

♿ **Accessibility**: Fixed missing alternative text on multiple images, ensuring keyboard/screen-reader users get context on images that convey information (avatars, map screenshots, venue thumbnails).

---
*PR created automatically by Jules for task [9184346086749416519](https://jules.google.com/task/9184346086749416519) started by @mbarbine*