### PR TITLE
⚡ Bolt: [performance improvement] Add native lazy loading to API Sandbox grid images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 ## 2026-03-22 - [Caching Static External API Calls]
 **Learning:** Some controller endpoints (like `/api/lastfm`) make external API calls for static data (e.g., info about a specific artist "Roniit") that does not vary per user. Fetching this data from external APIs on every single user request introduces massive, unnecessary latency and wastes API rate limits.
 **Action:** When an endpoint fetches external data that is static across all users and uses a global application key (not a user-specific OAuth token), implement a module-level cache (e.g., `let cache = null; let cacheTime = 0;`) with a reasonable duration (e.g., 5 minutes) to serve the data instantly and reduce network overhead.
+## 2026-04-08 - Added Native Lazy Loading to Image Grids
+**Learning:** Found an opportunity to improve frontend initial load times in Pug templates containing large image grids (`views/api/index.pug`) by adding the native `loading='lazy'` attribute.
+**Action:** Always check loop constructs or large grids of static images in views (especially logos or thumbnails) for missing lazy loading to easily defer below-the-fold asset loading.

--- a/views/api/index.pug
+++ b/views/api/index.pug
@@ -9,143 +9,143 @@ block content
       a(href='/api/github', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/2AaBlpf.png', height=40, alt='')
+            img(src='https://i.imgur.com/2AaBlpf.png', height=40, alt='', loading='lazy')
             |  GitHub
     .col-md-4
       a(href='/api/twitter', style='color: #fff')
         .card(style='background-color: #00abf0').mb-3
           .card-body
-            img(src='https://i.imgur.com/EYA2FO1.png', height=40, alt='')
+            img(src='https://i.imgur.com/EYA2FO1.png', height=40, alt='', loading='lazy')
             |  Twitter
     .col-md-4
       a(href='/api/facebook', style='color: #fff')
         .card(style='background-color: #3b5998').mb-3
           .card-body
-            img(src='https://i.imgur.com/jiztYCH.png', height=40, alt='')
+            img(src='https://i.imgur.com/jiztYCH.png', height=40, alt='', loading='lazy')
             |  Facebook
     .col-md-4
       a(href='/api/foursquare', style='color: #fff')
         .card(style='background-color: #1cafec').mb-3
           .card-body
-            img(src='https://i.imgur.com/PixH9li.png', height=40, alt='')
+            img(src='https://i.imgur.com/PixH9li.png', height=40, alt='', loading='lazy')
             |  Foursquare
     .col-md-4
       a(href='/api/instagram', style='color: #fff')
         .card(style='background-color: #947563').mb-3
           .card-body
-            img(src='https://i.imgur.com/aRc6LUJ.png', height=40, alt='')
+            img(src='https://i.imgur.com/aRc6LUJ.png', height=40, alt='', loading='lazy')
             |  Instagram
     .col-md-4
       a(href='/api/lastfm', style='color: #fff')
         .card(style='background-color: #d21309').mb-3
           .card-body
-            img(src='https://i.imgur.com/KfZY876.png', height=40, alt='')
+            img(src='https://i.imgur.com/KfZY876.png', height=40, alt='', loading='lazy')
             |  Last.fm
     .col-md-4
       a(href='/api/nyt', style='color: #fff')
         .card(style='background-color: #454442').mb-3
           .card-body
-            img(src='https://i.imgur.com/e3sjmYj.png', height=40, alt='')
+            img(src='https://i.imgur.com/e3sjmYj.png', height=40, alt='', loading='lazy')
             |  New York Times
     .col-md-4
       a(href='/api/steam', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/6WXcNeg.png', height=40, alt='')
+            img(src='https://i.imgur.com/6WXcNeg.png', height=40, alt='', loading='lazy')
             |  Steam
     .col-md-4
       a(href='/api/twitch', style='color: #fff')
         .card(style='background-color: #6441a5').mb-3
           .card-body
-            img(src='https://i.imgur.com/dWEkSRX.png', height=40, alt='')
+            img(src='https://i.imgur.com/dWEkSRX.png', height=40, alt='', loading='lazy')
             |  Twitch
     .col-md-4
       a(href='/api/stripe', style='color: #fff')
         .card(style='background-color: #3da8e5').mb-3
           .card-body
-            img(src='https://i.imgur.com/w3s2RvW.png', height=40, alt='')
+            img(src='https://i.imgur.com/w3s2RvW.png', height=40, alt='', loading='lazy')
             |  Stripe
     .col-md-4
       a(href='/api/paypal', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNc0iaX.png', height=40, alt='')
+            img(src='https://i.imgur.com/JNc0iaX.png', height=40, alt='', loading='lazy')
             |  PayPal
     .col-md-4
       a(href='/api/quickbooks', style='color: #fff')
         .card(style='background-color: #0077C5').mb-3
           .card-body
-            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='')
+            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='', loading='lazy')
             |  QuickBooks
     .col-md-4
       a(href='/api/twilio', style='color: #fff')
         .card(style='background-color: #fd0404').mb-3
           .card-body
-            img(src='https://i.imgur.com/mEUd6zM.png', height=40, alt='')
+            img(src='https://i.imgur.com/mEUd6zM.png', height=40, alt='', loading='lazy')
             |  Twilio
     .col-md-4
       a(href='/api/tumblr', style='color: #fff')
         .card(style='background-color: #304e6c').mb-3
           .card-body
-            img(src='https://i.imgur.com/rZGQShS.png', height=40, alt='')
+            img(src='https://i.imgur.com/rZGQShS.png', height=40, alt='', loading='lazy')
             |  Tumblr
     .col-md-4
       a(href='/api/scraping', style='color: #fff')
         .card(style='background-color: #ff6500').mb-3
           .card-body
-            img(src='https://i.imgur.com/RGCVvyR.png', height=40, alt='')
+            img(src='https://i.imgur.com/RGCVvyR.png', height=40, alt='', loading='lazy')
             |  Web Scraping
     .col-md-4
       a(href='/api/clockwork', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='')
+            img(src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='', loading='lazy')
             |  Clockwork SMS
     .col-md-4
       a(href='/api/lob', style='color: #fff')
         .card(style='background-color: #176992').mb-3
           .card-body
-            img(src='https://i.imgur.com/bmgfsSg.png', height=40, alt='')
+            img(src='https://i.imgur.com/bmgfsSg.png', height=40, alt='', loading='lazy')
             |  Lob
     .col-md-4
       a(href='/api/upload', style='color: #1565c0')
         .card(style='background-color: #fff').mb-3
           .card-body
-            img(src='https://i.imgur.com/UPTzIdC.png', height=40, alt='')
+            img(src='https://i.imgur.com/UPTzIdC.png', height=40, alt='', loading='lazy')
             |  File Upload
     .col-md-4
       a(href='/api/pinterest', style='color: #fff')
         .card(style='background-color: #bd081c').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNNRQSm.png', height=40, alt='')
+            img(src='https://i.imgur.com/JNNRQSm.png', height=40, alt='', loading='lazy')
             |  Pinterest
     .col-md-4
       a(href='/api/google-maps', style='color: #fff')
         .card(style='background-color: #20a360').mb-3
           .card-body
-            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='')
+            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='', loading='lazy')
             |  Google Maps
     .col-md-4
       a(href='/api/here-maps', style='color: #0f1621')
         .card(style='background-color: #d1f6f3').mb-3
           .card-body
-            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='')
+            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='', loading='lazy')
             |  HERE Maps
     .col-md-4
       a(href='/api/chart', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='')
+            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='', loading='lazy')
             |  Chart.js + Alpha Vantage
     .col-md-4
       a(href='/api/google/drive', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='')
+            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='', loading='lazy')
             |  Google Drive
     .col-md-4
       a(href='/api/google/sheets', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='')
+            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='', loading='lazy')
             |  Google Sheets


### PR DESCRIPTION
💡 **What:** Added the `loading='lazy'` native HTML attribute to all `img` tags within the API Sandbox grid (`views/api/index.pug`).

🎯 **Why:** The API Sandbox page displays 24 external image assets simultaneously on load. By default, browsers eagerly fetch all these images regardless of whether they are visible in the viewport. This delays the `load` event, uses unnecessary initial bandwidth, and slows down rendering.

📊 **Impact:** 
- **Faster initial page load:** Browsers will only fetch the images immediately visible in the viewport. The rest are deferred until the user scrolls.
- **Saved bandwidth:** Users who don't scroll won't download unnecessary assets.
- **Safe:** Native lazy loading falls back gracefully to standard eager loading in older browsers, introducing zero risk of breaking functionality.

🔬 **Measurement:** Verify by loading the `/api` route in Chrome DevTools (Network tab) and observing that only the first few images are requested initially. Scrolling down will trigger requests for the subsequent images.

---
*PR created automatically by Jules for task [9058703026786623845](https://jules.google.com/task/9058703026786623845) started by @mbarbine*