### PR TITLE
⚡ Bolt: Add native lazy loading to API index grid images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 ## 2026-03-22 - [Caching Static External API Calls]
 **Learning:** Some controller endpoints (like `/api/lastfm`) make external API calls for static data (e.g., info about a specific artist "Roniit") that does not vary per user. Fetching this data from external APIs on every single user request introduces massive, unnecessary latency and wastes API rate limits.
 **Action:** When an endpoint fetches external data that is static across all users and uses a global application key (not a user-specific OAuth token), implement a module-level cache (e.g., `let cache = null; let cacheTime = 0;`) with a reasonable duration (e.g., 5 minutes) to serve the data instantly and reduce network overhead.
+## 2026-04-10 - Native Lazy Loading on Image Grids
+**Learning:** Adding the native `loading="lazy"` attribute to image tags is a safe, zero-dependency micro-optimization for views with many off-screen images (like the API Sandbox grid). It defers image loading, saves bandwidth, and speeds up initial page load, and degrades gracefully on older browsers.
+**Action:** Always check loop-generated image grids and long pages for missing `loading="lazy"` attributes to implement an easy frontend performance win without adding complex JS libraries.

--- a/views/api/index.pug
+++ b/views/api/index.pug
@@ -4,148 +4,150 @@ block content
   .pb-2.mt-2.mb-4.border-bottom
     h3 API Sandbox
 
+  // ⚡ Bolt: Added native loading="lazy" to all API grid images to defer network requests for off-screen assets and speed up initial page load.
+
   .row
     .col-md-4
       a(href='/api/github', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/2AaBlpf.png', height=40, alt='')
+            img(src='https://i.imgur.com/2AaBlpf.png', height=40, alt='', loading='lazy')
             |  GitHub
     .col-md-4
       a(href='/api/twitter', style='color: #fff')
         .card(style='background-color: #00abf0').mb-3
           .card-body
-            img(src='https://i.imgur.com/EYA2FO1.png', height=40, alt='')
+            img(src='https://i.imgur.com/EYA2FO1.png', height=40, alt='', loading='lazy')
             |  Twitter
     .col-md-4
       a(href='/api/facebook', style='color: #fff')
         .card(style='background-color: #3b5998').mb-3
           .card-body
-            img(src='https://i.imgur.com/jiztYCH.png', height=40, alt='')
+            img(src='https://i.imgur.com/jiztYCH.png', height=40, alt='', loading='lazy')
             |  Facebook
     .col-md-4
       a(href='/api/foursquare', style='color: #fff')
         .card(style='background-color: #1cafec').mb-3
           .card-body
-            img(src='https://i.imgur.com/PixH9li.png', height=40, alt='')
+            img(src='https://i.imgur.com/PixH9li.png', height=40, alt='', loading='lazy')
             |  Foursquare
     .col-md-4
       a(href='/api/instagram', style='color: #fff')
         .card(style='background-color: #947563').mb-3
           .card-body
-            img(src='https://i.imgur.com/aRc6LUJ.png', height=40, alt='')
+            img(src='https://i.imgur.com/aRc6LUJ.png', height=40, alt='', loading='lazy')
             |  Instagram
     .col-md-4
       a(href='/api/lastfm', style='color: #fff')
         .card(style='background-color: #d21309').mb-3
           .card-body
-            img(src='https://i.imgur.com/KfZY876.png', height=40, alt='')
+            img(src='https://i.imgur.com/KfZY876.png', height=40, alt='', loading='lazy')
             |  Last.fm
     .col-md-4
       a(href='/api/nyt', style='color: #fff')
         .card(style='background-color: #454442').mb-3
           .card-body
-            img(src='https://i.imgur.com/e3sjmYj.png', height=40, alt='')
+            img(src='https://i.imgur.com/e3sjmYj.png', height=40, alt='', loading='lazy')
             |  New York Times
     .col-md-4
       a(href='/api/steam', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/6WXcNeg.png', height=40, alt='')
+            img(src='https://i.imgur.com/6WXcNeg.png', height=40, alt='', loading='lazy')
             |  Steam
     .col-md-4
       a(href='/api/twitch', style='color: #fff')
         .card(style='background-color: #6441a5').mb-3
           .card-body
-            img(src='https://i.imgur.com/dWEkSRX.png', height=40, alt='')
+            img(src='https://i.imgur.com/dWEkSRX.png', height=40, alt='', loading='lazy')
             |  Twitch
     .col-md-4
       a(href='/api/stripe', style='color: #fff')
         .card(style='background-color: #3da8e5').mb-3
           .card-body
-            img(src='https://i.imgur.com/w3s2RvW.png', height=40, alt='')
+            img(src='https://i.imgur.com/w3s2RvW.png', height=40, alt='', loading='lazy')
             |  Stripe
     .col-md-4
       a(href='/api/paypal', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNc0iaX.png', height=40, alt='')
+            img(src='https://i.imgur.com/JNc0iaX.png', height=40, alt='', loading='lazy')
             |  PayPal
     .col-md-4
       a(href='/api/quickbooks', style='color: #fff')
         .card(style='background-color: #0077C5').mb-3
           .card-body
-            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='')
+            img(src='https://quickbooks.intuit.com/cas/dam/IMAGE/A6OWCozsM/qb_thumb.png', height=40, alt='', loading='lazy')
             |  QuickBooks
     .col-md-4
       a(href='/api/twilio', style='color: #fff')
         .card(style='background-color: #fd0404').mb-3
           .card-body
-            img(src='https://i.imgur.com/mEUd6zM.png', height=40, alt='')
+            img(src='https://i.imgur.com/mEUd6zM.png', height=40, alt='', loading='lazy')
             |  Twilio
     .col-md-4
       a(href='/api/tumblr', style='color: #fff')
         .card(style='background-color: #304e6c').mb-3
           .card-body
-            img(src='https://i.imgur.com/rZGQShS.png', height=40, alt='')
+            img(src='https://i.imgur.com/rZGQShS.png', height=40, alt='', loading='lazy')
             |  Tumblr
     .col-md-4
       a(href='/api/scraping', style='color: #fff')
         .card(style='background-color: #ff6500').mb-3
           .card-body
-            img(src='https://i.imgur.com/RGCVvyR.png', height=40, alt='')
+            img(src='https://i.imgur.com/RGCVvyR.png', height=40, alt='', loading='lazy')
             |  Web Scraping
     .col-md-4
       a(href='/api/clockwork', style='color: #fff')
         .card(style='background-color: #000').mb-3
           .card-body
-            img(src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='')
+            img(src='https://i.imgur.com/YcdxZ5F.png', height=40, alt='', loading='lazy')
             |  Clockwork SMS
     .col-md-4
       a(href='/api/lob', style='color: #fff')
         .card(style='background-color: #176992').mb-3
           .card-body
-            img(src='https://i.imgur.com/bmgfsSg.png', height=40, alt='')
+            img(src='https://i.imgur.com/bmgfsSg.png', height=40, alt='', loading='lazy')
             |  Lob
     .col-md-4
       a(href='/api/upload', style='color: #1565c0')
         .card(style='background-color: #fff').mb-3
           .card-body
-            img(src='https://i.imgur.com/UPTzIdC.png', height=40, alt='')
+            img(src='https://i.imgur.com/UPTzIdC.png', height=40, alt='', loading='lazy')
             |  File Upload
     .col-md-4
       a(href='/api/pinterest', style='color: #fff')
         .card(style='background-color: #bd081c').mb-3
           .card-body
-            img(src='https://i.imgur.com/JNNRQSm.png', height=40, alt='')
+            img(src='https://i.imgur.com/JNNRQSm.png', height=40, alt='', loading='lazy')
             |  Pinterest
     .col-md-4
       a(href='/api/google-maps', style='color: #fff')
         .card(style='background-color: #20a360').mb-3
           .card-body
-            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='')
+            img(src='https://i.imgur.com/Er2ZqgZ.png', height=40, alt='', loading='lazy')
             |  Google Maps
     .col-md-4
       a(href='/api/here-maps', style='color: #0f1621')
         .card(style='background-color: #d1f6f3').mb-3
           .card-body
-            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='')
+            img(src='https://embed.widencdn.net/img/here/k906l0jhhc/x48px/HERE_Logo_2016_POS_sRGB.png', height=40, alt='', loading='lazy')
             |  HERE Maps
     .col-md-4
       a(href='/api/chart', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='')
+            img(src='https://www.chartjs.org/img/chartjs-logo.svg', height=40, alt='', loading='lazy')
             |  Chart.js + Alpha Vantage
     .col-md-4
       a(href='/api/google/drive', style='color: #000')
         .card(style='background-color: #FFFFFF').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='')
+            img(src='https://www.gstatic.com/images/branding/product/1x/drive_48dp.png', height=40, alt='', loading='lazy')
             |  Google Drive
     .col-md-4
       a(href='/api/google/sheets', style='color: #000')
         .card(style='background-color: #f5f5f5').mb-3
           .card-body
-            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='')
+            img(src='https://www.gstatic.com/images/icons/material/product/1x/sheets_64dp.png', height=40, alt='', loading='lazy')
             |  Google Sheets


### PR DESCRIPTION
### 💡 What
Added native `loading="lazy"` attribute to all 24 logo images in the API Sandbox grid (`views/api/index.pug`). Also added an inline comment explaining the optimization.

### 🎯 Why
When navigating to the `/api` page, the browser attempts to download all 24 high-resolution API logos at once. For users on slower connections or smaller devices where many of these logos are initially off-screen (below the fold), this consumes unnecessary bandwidth and delays the `load` event.

### 📊 Impact
*   **Faster Initial Load:** Defers the downloading of off-screen images.
*   **Reduced Bandwidth:** Only downloads images the user actually scrolls to see.
*   **Graceful Degradation:** The native `loading="lazy"` attribute degrades perfectly on older browsers, meaning it has zero risk of causing regressions or breaking UI layouts.

### 🔬 Measurement
1. Open Chrome DevTools > Network tab.
2. Ensure "Disable cache" is checked.
3. Reload `/api`. Observe that only the images visible in the initial viewport are downloaded.
4. Scroll down the page and observe the remaining images being requested dynamically.

---
*PR created automatically by Jules for task [17209976479273767635](https://jules.google.com/task/17209976479273767635) started by @mbarbine*