### PR TITLE
🛡️ Sentinel: [HIGH] Fix Arbitrary Field Deletion in OAuth unlink

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -30,3 +30,8 @@
 **Vulnerability:** The application attempted to prevent open redirects by verifying that `req.session.returnTo` matched `/^\/[^\/]/`. However, an attacker could supply a path like `/\evil.com`, which Express and browsers treat as `//evil.com`, leading to an open redirect.
 **Learning:** Checking that a URL path starts with a single slash and is not followed by another forward slash is insufficient protection for open redirects. Backslashes (`\`) can act similarly to forward slashes in URL parsing contexts, allowing for protocol-relative bypasses.
 **Prevention:** Update regex validation for absolute local paths to also reject backslashes. For example, use `/^\/[^\/\\]/` to enforce that the path begins strictly with `/` followed by any character except `/` or `\`.
+
+## 2024-04-12 - Prevent Arbitrary Field Deletion in Mongoose Document Update
+**Vulnerability:** Arbitrary field deletion/modification via Insecure Direct Object Reference (IDOR) on Mongoose objects in `controllers/user.js`. The OAuth provider unlinking feature (`getOauthUnlink`) allowed users to delete arbitrary Mongoose object properties by accepting unvalidated, dynamic `provider` values from the route parameter (e.g., `user[provider.toLowerCase()] = undefined;`).
+**Learning:** In dynamically-typed environments, accessing/modifying object properties dynamically using unvalidated user input directly exposes the underlying object structure (and potentially critical fields, like `email` or `password`) to modification or destruction.
+**Prevention:** Always validate unconstrained user inputs used as keys against a static allowlist (e.g., expected OAuth providers) before using them to access or modify properties on database models or objects.

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -227,6 +227,13 @@ exports.postDeleteAccount = (req, res, next) => {
  */
 exports.getOauthUnlink = (req, res, next) => {
   const { provider } = req.params;
+
+  const allowedProviders = ['snapchat', 'facebook', 'twitter', 'google', 'github', 'instagram', 'linkedin', 'steam', 'twitch', 'quickbooks'];
+  if (!allowedProviders.includes(provider.toLowerCase())) {
+    req.flash('errors', { msg: 'Invalid OAuth Provider.' });
+    return res.redirect('/account');
+  }
+
   User.findById(req.user.id, (err, user) => {
     if (err) { return next(err); }
     user[provider.toLowerCase()] = undefined;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Arbitrary Object Modification (or Mass Assignment) / IDOR. The `/account/unlink/:provider` endpoint used the dynamically provided `provider` string directly as a key to unset fields on the user's Mongoose document. By sending something like `email` or `password` as the provider parameter, a user could delete their own credentials from the database.
🎯 Impact: A user could intentionally or accidentally delete their own email or password fields, causing denial of service to their account, or in extreme cases, bypassing certain login logic.
🔧 Fix: Validated that the `provider` argument strictly exists within an expected allowlist (`['snapchat', 'facebook', 'twitter', 'google', 'github', 'instagram', 'linkedin', 'steam', 'twitch', 'quickbooks']`) before modifying the `user` document.
✅ Verification: Review the patch to ensure the list of allowed providers is comprehensive for this project and the fallback redirects cleanly.

---
*PR created automatically by Jules for task [16730951821647700802](https://jules.google.com/task/16730951821647700802) started by @mbarbine*