### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Arbitrary Field Deletion via OAuth Unlink

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -30,3 +30,7 @@
 **Vulnerability:** The application attempted to prevent open redirects by verifying that `req.session.returnTo` matched `/^\/[^\/]/`. However, an attacker could supply a path like `/\evil.com`, which Express and browsers treat as `//evil.com`, leading to an open redirect.
 **Learning:** Checking that a URL path starts with a single slash and is not followed by another forward slash is insufficient protection for open redirects. Backslashes (`\`) can act similarly to forward slashes in URL parsing contexts, allowing for protocol-relative bypasses.
 **Prevention:** Update regex validation for absolute local paths to also reject backslashes. For example, use `/^\/[^\/\\]/` to enforce that the path begins strictly with `/` followed by any character except `/` or `\`.
+## 2024-05-24 - [CRITICAL] Arbitrary Field Deletion via dynamic model property access
+**Vulnerability:** User-provided string from URL parameter (`req.params.provider`) was used as a dynamic object property key on the Mongoose user model `user[provider.toLowerCase()] = undefined` to delete OAuth properties. A malicious user could send `password`, `email`, or other critical fields as the provider to arbitrarily delete data and disrupt the service.
+**Learning:** Never trust user input to directly index and modify model properties in Mongoose or ORMs.
+**Prevention:** Always validate user input against a strict allowlist of fields (e.g., specific OAuth provider names) before using it as an object key to modify data.

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -226,12 +226,20 @@ exports.postDeleteAccount = (req, res, next) => {
  * Unlink OAuth provider.
  */
 exports.getOauthUnlink = (req, res, next) => {
-  const { provider } = req.params;
+  let { provider } = req.params;
+  provider = String(provider || '').toLowerCase();
+  const allowedProviders = ['snapchat', 'facebook', 'twitter', 'google', 'github', 'instagram', 'linkedin', 'steam', 'twitch', 'quickbooks', 'foursquare', 'tumblr', 'pinterest'];
+
+  if (!allowedProviders.includes(provider)) {
+    req.flash('errors', { msg: 'Invalid OAuth Provider' });
+    return res.redirect('/account');
+  }
+
   User.findById(req.user.id, (err, user) => {
     if (err) { return next(err); }
-    user[provider.toLowerCase()] = undefined;
+    user[provider] = undefined;
     const tokensWithoutProviderToUnlink = user.tokens.filter((token) =>
-      token.kind !== provider.toLowerCase());
+      token.kind !== provider);
     // Some auth providers do not provide an email address in the user profile.
     // As a result, we need to verify that unlinking the provider is safe by ensuring
     // that another login method exists.


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Arbitrary Field Deletion via OAuth Unlink

🚨 Severity: CRITICAL
💡 Vulnerability: Arbitrary Field Deletion / Insecure Direct Object Reference (IDOR). `getOauthUnlink` previously used the user-controlled `req.params.provider` string directly as a key on the `user` document to set properties to undefined (`user[provider.toLowerCase()] = undefined;`).
🎯 Impact: An attacker could pass `password`, `email`, or other critical internal fields as the `:provider` in the URL to delete those fields from their account, leading to data destruction or bypassing login conditions.
🔧 Fix: Validated `req.params.provider` against a hardcoded array of allowed OAuth provider strings. If the parameter is invalid, it redirects the user back with an error flash message.
✅ Verification: Tested manually with a standalone script passing invalid inputs (e.g., `password`, `__proto__`) and ensuring the validation logic correctly catches and rejects them. Syntax is verified.

---
*PR created automatically by Jules for task [12567501523467242398](https://jules.google.com/task/12567501523467242398) started by @mbarbine*