### PR TITLE
🎨 Palette: Add context-aware alt attribute to Foursquare venue photo

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,6 @@
 ## 2026-03-26 - Missing form labels in Twitter API view
 **Learning:** Found an accessibility issue pattern where inputs in views (like the Compose Tweet field) were completely lacking labels, forcing screen readers to guess their purpose.
 **Action:** Always verify that input fields have either a visible label or a screen-reader-only (`.sr-only`) label connected via `for`/`id` attributes.
+## 2024-04-15 - Context-aware alt attributes for dynamic templates
+**Learning:** When adding `alt` attributes to images generated via loops or complex objects in Pug templates (e.g. `venueDetail.venue.photos...`), use the closest relevant text variable (like `venueDetail.venue.name + ' photo'`) rather than generic text. This improves screen reader context significantly and ensures each dynamic image has a unique, descriptive label.
+**Action:** Always inspect the surrounding template code or controller structure to find available variables for contextual image descriptions.

--- a/views/api/foursquare.pug
+++ b/views/api/foursquare.pug
@@ -34,7 +34,7 @@ block content
   br
   h3.text-primary Venue Detail
   p
-    img(src=venueDetail.venue.photos.groups[0].items[0].prefix + '150x150' + venueDetail.venue.photos.groups[0].items[0].suffix)
+    img(src=venueDetail.venue.photos.groups[0].items[0].prefix + '150x150' + venueDetail.venue.photos.groups[0].items[0].suffix, alt=venueDetail.venue.name + ' photo')
 
   .badge.badge-primary #{venueDetail.venue.name} (#{venueDetail.venue.categories[0].shortName})
   .badge.badge-success #{venueDetail.venue.location.address}, #{venueDetail.venue.location.city}, #{venueDetail.venue.location.state}


### PR DESCRIPTION
This PR adds a dynamic `alt` attribute to the venue photo in the Foursquare API view, which improves accessibility for screen readers and provides a meaningful fallback if the image fails to load.

**💡 What:** The UX enhancement added: `alt=venueDetail.venue.name + ' photo'` to the image tag in `views/api/foursquare.pug`.
**🎯 Why:** The user problem it solves: Screen readers previously read the raw image URL for the venue photo. Now they will read the actual venue name followed by "photo".
**📸 Before/After:** N/A (structural change)
**♿ Accessibility:** Added a contextual `alt` attribute to a dynamic image generated from an API response.

---
*PR created automatically by Jules for task [1036669874182071403](https://jules.google.com/task/1036669874182071403) started by @mbarbine*