### PR TITLE
🎨 Palette: Add missing alt attributes to images in API views

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,6 @@
 ## 2026-03-26 - Missing form labels in Twitter API view
 **Learning:** Found an accessibility issue pattern where inputs in views (like the Compose Tweet field) were completely lacking labels, forcing screen readers to guess their purpose.
 **Action:** Always verify that input fields have either a visible label or a screen-reader-only (`.sr-only`) label connected via `for`/`id` attributes.
+## 2026-03-31 - Missing alt attributes on individual view images
+**Learning:** Found an accessibility issue pattern where individual images (like the Tumblr photo, Google Drive icons, HERE Map, profile pictures in Facebook and Instagram, and venue pictures in Foursquare) consistently lacked `alt` attributes, making them inaccessible to screen readers.
+**Action:** Always verify `alt` attributes are present when creating or modifying views that include dynamic or static images, and provide meaningful descriptions (e.g. `alt=venueDetail.venue.name` or `alt='Profile picture'`).

--- a/views/api/facebook.pug
+++ b/views/api/facebook.pug
@@ -19,7 +19,7 @@ block content
   h3
     i.far.fa-user.fa-sm
     |  My Profile
-  img.thumbnail(src=`https://graph.facebook.com/${profile.id}/picture?type=large`, width='90', height='90')
+  img.thumbnail(src=`https://graph.facebook.com/${profile.id}/picture?type=large`, width='90', height='90', alt='Profile picture')
   h4= profile.name
   h6 First Name: #{profile.first_name}
   h6 Last Name: #{profile.last_name}

--- a/views/api/foursquare.pug
+++ b/views/api/foursquare.pug
@@ -34,7 +34,7 @@ block content
   br
   h3.text-primary Venue Detail
   p
-    img(src=venueDetail.venue.photos.groups[0].items[0].prefix + '150x150' + venueDetail.venue.photos.groups[0].items[0].suffix)
+    img(src=venueDetail.venue.photos.groups[0].items[0].prefix + '150x150' + venueDetail.venue.photos.groups[0].items[0].suffix, alt=venueDetail.venue.name)
 
   .badge.badge-primary #{venueDetail.venue.name} (#{venueDetail.venue.categories[0].shortName})
   .badge.badge-success #{venueDetail.venue.location.address}, #{venueDetail.venue.location.city}, #{venueDetail.venue.location.state}

--- a/views/api/google-drive.pug
+++ b/views/api/google-drive.pug
@@ -21,7 +21,7 @@ block content
       | The list of files at the root of your Google Drive
     for file in files
       li
-        img(src=file.iconLink)
+        img(src=file.iconLink, alt='')
         | 
         a(href=file.webViewLink, target="_blank")
          =file.name

--- a/views/api/here-maps.pug
+++ b/views/api/here-maps.pug
@@ -20,7 +20,7 @@ block content
   div(style='display:flex; justify-content: center;')
     | This non-interactive map renders without the use of any client-side scripts:
   div(style='display:flex; justify-content: center;')
-    img(src= imageMapURL)
+    img(src= imageMapURL, alt='HERE Map')
 
   br
   .pb-2.mt-2.mt-4.border-top

--- a/views/api/instagram.pug
+++ b/views/api/instagram.pug
@@ -26,4 +26,4 @@ block content
     for image in myRecentMedia
       .col-xs-3
         a.thumbnail(href=image.link)
-          img(src=image.images.standard_resolution.url, height='320px')
+          img(src=image.images.standard_resolution.url, height='320px', alt='Instagram photo')

--- a/views/api/lastfm.pug
+++ b/views/api/lastfm.pug
@@ -21,7 +21,7 @@ block content
   else
     h3= artist.name
     if artist.image
-      img.thumbnail(src='' + artist.image)
+      img.thumbnail(src='' + artist.image, alt=artist.name + ' image')
 
     h3 Tags
     for tag in artist.tags
@@ -38,7 +38,7 @@ block content
 
     h3 Top Albums
     for album in artist.topAlbums
-      img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150)
+      img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150, alt=album.name + ' image')
       | &nbsp;
 
     h3 Top Tracks

--- a/views/api/tumblr.pug
+++ b/views/api/tumblr.pug
@@ -23,4 +23,4 @@ block content
     | #{blog.posts} posts
   h4 Latest Photo Post
   for photo in photoset
-    img.item(src=photo.original_size.url)
+    img.item(src=photo.original_size.url, alt='Tumblr photo')


### PR DESCRIPTION
💡 **What**: Added `alt` attributes to `img` tags across several `.pug` views in the `views/api/` directory (Facebook, Foursquare, Google Drive, HERE Maps, Instagram, Last.fm, and Tumblr).
🎯 **Why**: Many individual images in these views lacked alternative text, causing screen readers to read out raw image URLs instead of meaningful descriptions. Adding appropriate text (or an empty string for decorative/redundant images) significantly improves accessibility for users relying on assistive technologies.
♿ **Accessibility**: Provided meaningful `alt` text using dynamic data (like `venueDetail.venue.name` or `album.name`) where appropriate, and empty strings (`alt=''`) where the image was purely decorative or redundant to adjacent text.

---
*PR created automatically by Jules for task [6726119269021517127](https://jules.google.com/task/6726119269021517127) started by @mbarbine*