### PR TITLE
🎨 Palette: Add missing alt attributes to API view images

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,6 @@
 ## 2026-03-26 - Missing form labels in Twitter API view
 **Learning:** Found an accessibility issue pattern where inputs in views (like the Compose Tweet field) were completely lacking labels, forcing screen readers to guess their purpose.
 **Action:** Always verify that input fields have either a visible label or a screen-reader-only (`.sr-only`) label connected via `for`/`id` attributes.
+## 2024-05-24 - Missing Alt Attributes in API Views
+**Learning:** Many views in the `api` folder use `img` tags to display user profiles, album covers, or API-specific icons (like Foursquare venues or Google Drive icons), but lack `alt` tags. Because they are often dynamically populated (e.g., `artist.image`), they are easily missed during copy-pasting.
+**Action:** When working on API or user profile views, consistently verify that `img` tags include contextual `alt` attributes based on template variables (e.g., `alt=artist.name + ' profile picture'`) to improve accessibility.

--- a/views/api/facebook.pug
+++ b/views/api/facebook.pug
@@ -19,7 +19,7 @@ block content
   h3
     i.far.fa-user.fa-sm
     |  My Profile
-  img.thumbnail(src=`https://graph.facebook.com/${profile.id}/picture?type=large`, width='90', height='90')
+  img.thumbnail(src=`https://graph.facebook.com/${profile.id}/picture?type=large`, width='90', height='90', alt=profile.name + ' profile picture')
   h4= profile.name
   h6 First Name: #{profile.first_name}
   h6 Last Name: #{profile.last_name}

--- a/views/api/foursquare.pug
+++ b/views/api/foursquare.pug
@@ -34,7 +34,7 @@ block content
   br
   h3.text-primary Venue Detail
   p
-    img(src=venueDetail.venue.photos.groups[0].items[0].prefix + '150x150' + venueDetail.venue.photos.groups[0].items[0].suffix)
+    img(src=venueDetail.venue.photos.groups[0].items[0].prefix + '150x150' + venueDetail.venue.photos.groups[0].items[0].suffix, alt=venueDetail.venue.name + ' venue photo')
 
   .badge.badge-primary #{venueDetail.venue.name} (#{venueDetail.venue.categories[0].shortName})
   .badge.badge-success #{venueDetail.venue.location.address}, #{venueDetail.venue.location.city}, #{venueDetail.venue.location.state}

--- a/views/api/google-drive.pug
+++ b/views/api/google-drive.pug
@@ -21,7 +21,7 @@ block content
       | The list of files at the root of your Google Drive
     for file in files
       li
-        img(src=file.iconLink)
+        img(src=file.iconLink, alt=file.name + ' icon')
         | 
         a(href=file.webViewLink, target="_blank")
          =file.name

--- a/views/api/here-maps.pug
+++ b/views/api/here-maps.pug
@@ -20,7 +20,7 @@ block content
   div(style='display:flex; justify-content: center;')
     | This non-interactive map renders without the use of any client-side scripts:
   div(style='display:flex; justify-content: center;')
-    img(src= imageMapURL)
+    img(src= imageMapURL, alt='HERE map')
 
   br
   .pb-2.mt-2.mt-4.border-top

--- a/views/api/instagram.pug
+++ b/views/api/instagram.pug
@@ -26,4 +26,4 @@ block content
     for image in myRecentMedia
       .col-xs-3
         a.thumbnail(href=image.link)
-          img(src=image.images.standard_resolution.url, height='320px')
+          img(src=image.images.standard_resolution.url, height='320px', alt='Instagram recent media')

--- a/views/api/lastfm.pug
+++ b/views/api/lastfm.pug
@@ -21,7 +21,7 @@ block content
   else
     h3= artist.name
     if artist.image
-      img.thumbnail(src='' + artist.image)
+      img.thumbnail(src='' + artist.image, alt=artist.name + ' profile picture')
 
     h3 Tags
     for tag in artist.tags
@@ -38,7 +38,7 @@ block content
 
     h3 Top Albums
     for album in artist.topAlbums
-      img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150)
+      img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150, alt=album.name + ' album cover')
       | &nbsp;
 
     h3 Top Tracks

--- a/views/api/tumblr.pug
+++ b/views/api/tumblr.pug
@@ -23,4 +23,4 @@ block content
     | #{blog.posts} posts
   h4 Latest Photo Post
   for photo in photoset
-    img.item(src=photo.original_size.url)
+    img.item(src=photo.original_size.url, alt='Tumblr photo')


### PR DESCRIPTION
Adds context-aware `alt` attributes to images missing them across several API views (Foursquare, Tumblr, Google Drive, HERE Maps, Facebook, Instagram, Last.fm) to improve screen reader accessibility.

---
*PR created automatically by Jules for task [9955728625216534055](https://jules.google.com/task/9955728625216534055) started by @mbarbine*