### PR TITLE
🎨 Palette: Add aria-hidden to decorative icons in account views

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,6 @@
 ## 2024-05-24 - Missing Alt Attributes in API Views
 **Learning:** Many views in the `api` folder use `img` tags to display user profiles, album covers, or API-specific icons (like Foursquare venues or Google Drive icons), but lack `alt` tags. Because they are often dynamically populated (e.g., `artist.image`), they are easily missed during copy-pasting.
 **Action:** When working on API or user profile views, consistently verify that `img` tags include contextual `alt` attributes based on template variables (e.g., `alt=artist.name + ' profile picture'`) to improve accessibility.
+## 2026-04-22 - Hide decorative FontAwesome icons from screen readers
+**Learning:** Found an accessibility issue pattern where decorative FontAwesome icons (`i.fa-*`) placed alongside visible text inside buttons or links were being read out by screen readers, causing confusing or redundant announcements.
+**Action:** When adding or auditing buttons or links containing both an icon and text, always add `aria-hidden='true'` to the purely decorative `i` element to ensure screen readers skip it.

--- a/views/account/forgot.pug
+++ b/views/account/forgot.pug
@@ -12,5 +12,5 @@ block content
         input.form-control(type='email', name='email', id='email', placeholder='Email', autofocus, autocomplete='email', required)
     .form-group.offset-sm-3.col-md-7.pl-2
       button.btn.btn-primary(type='submit')
-        i.fas.fa-key.fa-sm
+        i.fas.fa-key.fa-sm(aria-hidden='true')
         | Reset Password

--- a/views/account/login.pug
+++ b/views/account/login.pug
@@ -16,7 +16,7 @@ block content
     .form-group
       .offset-md-3.col-md-7.pl-2
         button.col-md-3.btn.btn-primary(type='submit')
-          i.far.fa-user.fa-sm
+          i.far.fa-user.fa-sm(aria-hidden='true')
           | Login
         a.btn.btn-link(href='/forgot') Forgot your password?
     .form-group
@@ -25,26 +25,26 @@ block content
     .form-group
       .offset-md-3.col-md-7.pl-2
         a.btn.btn-block.btn-google.btn-social(href='/auth/google')
-          i.fab.fa-google-plus-g.fa-xs
+          i.fab.fa-google-plus-g.fa-xs(aria-hidden='true')
           | Sign in with Google
         a.btn.btn-block.btn-facebook.btn-social(href='/auth/facebook')
-          i.fab.fa-facebook-f.fa-sm
+          i.fab.fa-facebook-f.fa-sm(aria-hidden='true')
           | Sign in with Facebook
         a.btn.btn-block.btn-instagram.btn-social(href='/auth/instagram')
-          i.fab.fa-instagram.fa-sm
+          i.fab.fa-instagram.fa-sm(aria-hidden='true')
           | Sign in with Instagram
         a.btn.btn-block.btn-twitter.btn-social(href='/auth/twitter')
-          i.fab.fa-twitter.fa-sm
+          i.fab.fa-twitter.fa-sm(aria-hidden='true')
           | Sign in with Twitter
         a.btn.btn-block.btn-linkedin.btn-social(href='/auth/linkedin')
-          i.fab.fa-linkedin-in.fa-sm
+          i.fab.fa-linkedin-in.fa-sm(aria-hidden='true')
           | Sign in with LinkedIn
         a.btn.btn-block.btn-twitch.btn-social(href='/auth/twitch')
-          i.fab.fa-twitch.fa-sm
+          i.fab.fa-twitch.fa-sm(aria-hidden='true')
           | Sign in with Twitch
         a.btn.btn-block.btn-github.btn-social(href='/auth/github')
-          i.fab.fa-github.fa-sm
+          i.fab.fa-github.fa-sm(aria-hidden='true')
           | Sign in with GitHub
         a.btn.btn-block.btn-snapchat.btn-social(href='/auth/snapchat')
-          i.fab.fa-snapchat-ghost.fa-sm
+          i.fab.fa-snapchat-ghost.fa-sm(aria-hidden='true')
           | Sign in with Snapchat

--- a/views/account/profile.pug
+++ b/views/account/profile.pug
@@ -55,7 +55,7 @@ block content
     .form-group
       .offset-sm-3.col-md-7.pl-2
         button.btn.btn.btn-primary(type='submit')
-          i.fas.fa-pencil-alt.fa-sm
+          i.fas.fa-pencil-alt.fa-sm(aria-hidden='true')
           | Update Profile
 
   .pb-2.mt-2.mb-4.border-bottom
@@ -74,7 +74,7 @@ block content
     .form-group
       .offset-sm-3.col-md-7.pl-2
         button.btn.btn-primary(type='submit')
-          i.fas.fa-lock.fa-sm
+          i.fas.fa-lock.fa-sm(aria-hidden='true')
           | Change Password
 
   .pb-2.mt-2.mb-4.border-bottom
@@ -86,7 +86,7 @@ block content
       input(type='hidden', name='_csrf', value=_csrf)
       .offset-sm-3.col-md-7.pl-2
         button.btn.btn-danger(type='submit')
-          i.fas.fa-trash-alt.fa-sm
+          i.fas.fa-trash-alt.fa-sm(aria-hidden='true')
           | Delete my account
 
   .pb-2.mt-2.mb-4.border-bottom

--- a/views/account/reset.pug
+++ b/views/account/reset.pug
@@ -15,5 +15,5 @@ block content
         input.form-control(type='password', name='confirm', id='confirm', placeholder='Confirm password', autocomplete='new-password', minlength='8', required)
     .form-group.offset-sm-3.col-md-7.pl-2
       button.btn.btn-primary.btn-reset(type='submit')
-        i.far.fa-keyboard.fa-sm
+        i.far.fa-keyboard.fa-sm(aria-hidden='true')
         | Change Password

--- a/views/account/signup.pug
+++ b/views/account/signup.pug
@@ -19,5 +19,5 @@ block content
         input.form-control(type='password', name='confirmPassword', id='confirmPassword', placeholder='Confirm Password', autocomplete='new-password', minlength='8', required)
     .form-group.offset-sm-3.col-md-7.pl-2
       button.btn.btn-success(type='submit')
-        i.fas.fa-user-plus.fa-sm
+        i.fas.fa-user-plus.fa-sm(aria-hidden='true')
         | Signup


### PR DESCRIPTION
## 💡 What
Added `aria-hidden='true'` to purely decorative FontAwesome icons (`i.fa-*`) within buttons and links in the account-related Pug views.

## 🎯 Why
When an icon is placed next to text inside a button or link (e.g., `<button><i class="fas fa-key"></i> Reset Password</button>`), screen readers may attempt to read the icon class or a generic unicode character, causing confusing or redundant announcements. Adding `aria-hidden='true'` to the icon ensures screen readers ignore the decorative element and only announce the visible, meaningful text.

## ♿ Accessibility
Improves screen reader experience by hiding decorative elements that do not convey additional semantic meaning beyond the accompanying visible text.

---
*PR created automatically by Jules for task [7847033947471734808](https://jules.google.com/task/7847033947471734808) started by @mbarbine*