### PR TITLE
🎨 Palette: Add aria-hidden to decorative icons in login view

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,6 @@
 ## 2024-05-24 - Missing Alt Attributes in API Views
 **Learning:** Many views in the `api` folder use `img` tags to display user profiles, album covers, or API-specific icons (like Foursquare venues or Google Drive icons), but lack `alt` tags. Because they are often dynamically populated (e.g., `artist.image`), they are easily missed during copy-pasting.
 **Action:** When working on API or user profile views, consistently verify that `img` tags include contextual `alt` attributes based on template variables (e.g., `alt=artist.name + ' profile picture'`) to improve accessibility.
+## 2026-04-03 - Decorative FontAwesome Icons in Buttons
+**Learning:** Found an accessibility issue where decorative FontAwesome icons (`i.far.fa-user.fa-sm` and `i.fab.*`) inside login buttons were lacking `aria-hidden='true'`, which could cause screen readers to read confusing or redundant characters.
+**Action:** When working with buttons or links containing both text and decorative icons, ensure the icons are hidden from screen readers using `aria-hidden='true'`.

--- a/views/account/login.pug
+++ b/views/account/login.pug
@@ -16,7 +16,7 @@ block content
     .form-group
       .offset-md-3.col-md-7.pl-2
         button.col-md-3.btn.btn-primary(type='submit')
-          i.far.fa-user.fa-sm
+          i.far.fa-user.fa-sm(aria-hidden='true')
           | Login
         a.btn.btn-link(href='/forgot') Forgot your password?
     .form-group
@@ -25,26 +25,26 @@ block content
     .form-group
       .offset-md-3.col-md-7.pl-2
         a.btn.btn-block.btn-google.btn-social(href='/auth/google')
-          i.fab.fa-google-plus-g.fa-xs
+          i.fab.fa-google-plus-g.fa-xs(aria-hidden='true')
           | Sign in with Google
         a.btn.btn-block.btn-facebook.btn-social(href='/auth/facebook')
-          i.fab.fa-facebook-f.fa-sm
+          i.fab.fa-facebook-f.fa-sm(aria-hidden='true')
           | Sign in with Facebook
         a.btn.btn-block.btn-instagram.btn-social(href='/auth/instagram')
-          i.fab.fa-instagram.fa-sm
+          i.fab.fa-instagram.fa-sm(aria-hidden='true')
           | Sign in with Instagram
         a.btn.btn-block.btn-twitter.btn-social(href='/auth/twitter')
-          i.fab.fa-twitter.fa-sm
+          i.fab.fa-twitter.fa-sm(aria-hidden='true')
           | Sign in with Twitter
         a.btn.btn-block.btn-linkedin.btn-social(href='/auth/linkedin')
-          i.fab.fa-linkedin-in.fa-sm
+          i.fab.fa-linkedin-in.fa-sm(aria-hidden='true')
           | Sign in with LinkedIn
         a.btn.btn-block.btn-twitch.btn-social(href='/auth/twitch')
-          i.fab.fa-twitch.fa-sm
+          i.fab.fa-twitch.fa-sm(aria-hidden='true')
           | Sign in with Twitch
         a.btn.btn-block.btn-github.btn-social(href='/auth/github')
-          i.fab.fa-github.fa-sm
+          i.fab.fa-github.fa-sm(aria-hidden='true')
           | Sign in with GitHub
         a.btn.btn-block.btn-snapchat.btn-social(href='/auth/snapchat')
-          i.fab.fa-snapchat-ghost.fa-sm
+          i.fab.fa-snapchat-ghost.fa-sm(aria-hidden='true')
           | Sign in with Snapchat


### PR DESCRIPTION
💡 **What:** Added `aria-hidden='true'` to all FontAwesome icons within the login buttons in `views/account/login.pug`.
🎯 **Why:** To improve accessibility by preventing screen readers from redundantly announcing purely decorative icons that are immediately followed by descriptive text (e.g., "Login", "Sign in with Google").
♿ **Accessibility:** Prevents confusing or redundant screen reader announcements for decorative elements.

---
*PR created automatically by Jules for task [14815068653314011429](https://jules.google.com/task/14815068653314011429) started by @mbarbine*