### PR TITLE
🎨 Palette: Add aria-hidden to decorative icons in buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,3 +3,6 @@
 ## 2024-05-18 - Missing ARIA Labels on Close Buttons in Flash Messages
 **Learning:** Found an accessibility issue pattern where close buttons (`button.close`) for flash alerts in `views/partials/flash.pug` are missing `aria-label` attributes to explicitly tell screen reader users that the button closes the alert. The buttons currently contain an icon `i.far.fa-times-circle` but lack accessible names.
 **Action:** When working on flash messages or modals that have generic "close" icons, always verify they have an `aria-label="Close"` added to the `button` tag. This is a quick and effective a11y enhancement.
+## 2024-05-18 - Missing ARIA Hidden on Decorative Icons in Buttons
+**Learning:** Discovered an accessibility issue where purely decorative FontAwesome icons (e.g., `i.fa-*` inside buttons or links) alongside visible text were not hidden from screen readers. This can cause screen readers to announce confusing or redundant characters, degrading the user experience.
+**Action:** When adding or reviewing decorative icons next to visible text, always ensure they are given the `aria-hidden='true'` attribute.

--- a/views/account/login.pug
+++ b/views/account/login.pug
@@ -16,7 +16,7 @@ block content
     .form-group
       .offset-md-3.col-md-7.pl-2
         button.col-md-3.btn.btn-primary(type='submit')
-          i.far.fa-user.fa-sm
+          i.far.fa-user.fa-sm(aria-hidden='true')
           | Login
         a.btn.btn-link(href='/forgot') Forgot your password?
     .form-group
@@ -25,26 +25,26 @@ block content
     .form-group
       .offset-md-3.col-md-7.pl-2
         a.btn.btn-block.btn-google.btn-social(href='/auth/google')
-          i.fab.fa-google-plus-g.fa-xs
+          i.fab.fa-google-plus-g.fa-xs(aria-hidden='true')
           | Sign in with Google
         a.btn.btn-block.btn-facebook.btn-social(href='/auth/facebook')
-          i.fab.fa-facebook-f.fa-sm
+          i.fab.fa-facebook-f.fa-sm(aria-hidden='true')
           | Sign in with Facebook
         a.btn.btn-block.btn-instagram.btn-social(href='/auth/instagram')
-          i.fab.fa-instagram.fa-sm
+          i.fab.fa-instagram.fa-sm(aria-hidden='true')
           | Sign in with Instagram
         a.btn.btn-block.btn-twitter.btn-social(href='/auth/twitter')
-          i.fab.fa-twitter.fa-sm
+          i.fab.fa-twitter.fa-sm(aria-hidden='true')
           | Sign in with Twitter
         a.btn.btn-block.btn-linkedin.btn-social(href='/auth/linkedin')
-          i.fab.fa-linkedin-in.fa-sm
+          i.fab.fa-linkedin-in.fa-sm(aria-hidden='true')
           | Sign in with LinkedIn
         a.btn.btn-block.btn-twitch.btn-social(href='/auth/twitch')
-          i.fab.fa-twitch.fa-sm
+          i.fab.fa-twitch.fa-sm(aria-hidden='true')
           | Sign in with Twitch
         a.btn.btn-block.btn-github.btn-social(href='/auth/github')
-          i.fab.fa-github.fa-sm
+          i.fab.fa-github.fa-sm(aria-hidden='true')
           | Sign in with GitHub
         a.btn.btn-block.btn-snapchat.btn-social(href='/auth/snapchat')
-          i.fab.fa-snapchat-ghost.fa-sm
+          i.fab.fa-snapchat-ghost.fa-sm(aria-hidden='true')
           | Sign in with Snapchat

--- a/views/account/signup.pug
+++ b/views/account/signup.pug
@@ -19,5 +19,5 @@ block content
         input.form-control(type='password', name='confirmPassword', id='confirmPassword', placeholder='Confirm Password', autocomplete='new-password', minlength='8', required)
     .form-group.offset-sm-3.col-md-7.pl-2
       button.btn.btn-success(type='submit')
-        i.fas.fa-user-plus.fa-sm
+        i.fas.fa-user-plus.fa-sm(aria-hidden='true')
         | Signup


### PR DESCRIPTION
💡 **What:** Added `aria-hidden='true'` to purely decorative `i.fa-*` icons within the login and signup form buttons (`views/account/login.pug` and `views/account/signup.pug`).
🎯 **Why:** To prevent screen readers from reading out confusing or redundant characters for icons that are placed alongside visible text, resulting in a cleaner and more accessible audio experience.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Improved screen reader experience by explicitly hiding decorative font icons in key authentication flows.

---
*PR created automatically by Jules for task [140095582330303972](https://jules.google.com/task/140095582330303972) started by @mbarbine*