### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Arbitrary Field Deletion in OAuth Unlink

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -30,3 +30,7 @@
 **Vulnerability:** The application attempted to prevent open redirects by verifying that `req.session.returnTo` matched `/^\/[^\/]/`. However, an attacker could supply a path like `/\evil.com`, which Express and browsers treat as `//evil.com`, leading to an open redirect.
 **Learning:** Checking that a URL path starts with a single slash and is not followed by another forward slash is insufficient protection for open redirects. Backslashes (`\`) can act similarly to forward slashes in URL parsing contexts, allowing for protocol-relative bypasses.
 **Prevention:** Update regex validation for absolute local paths to also reject backslashes. For example, use `/^\/[^\/\\]/` to enforce that the path begins strictly with `/` followed by any character except `/` or `\`.
+## 2025-04-25 - Prevent IDOR in OAuth Unlink
+**Vulnerability:** Arbitrary Field Deletion / Prototype Pollution / Insecure Direct Object Reference (IDOR) via `req.params.provider` in `getOauthUnlink` route in `controllers/user.js`.
+**Learning:** `user[provider.toLowerCase()] = undefined;` without validation allowed users to pass arbitrary values (like 'password', 'email') in the URL and set those fields to `undefined` on their user object.
+**Prevention:** Always validate user input used as a key for property access or modification against a strict allowlist.

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -227,6 +227,13 @@ exports.postDeleteAccount = (req, res, next) => {
  */
 exports.getOauthUnlink = (req, res, next) => {
   const { provider } = req.params;
+  const allowedProviders = ['snapchat', 'facebook', 'twitter', 'google', 'github', 'instagram', 'linkedin', 'steam', 'twitch', 'quickbooks'];
+
+  if (!allowedProviders.includes(provider.toLowerCase())) {
+    req.flash('errors', { msg: 'Invalid OAuth Provider' });
+    return res.redirect('/account');
+  }
+
   User.findById(req.user.id, (err, user) => {
     if (err) { return next(err); }
     user[provider.toLowerCase()] = undefined;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Arbitrary Field Deletion / Prototype Pollution / Insecure Direct Object Reference (IDOR) in `getOauthUnlink` route (`controllers/user.js`). The route took an unvalidated `req.params.provider` and executed `user[provider.toLowerCase()] = undefined`.
🎯 Impact: An attacker could modify the URL to `.../unlink/password` or `.../unlink/email` and bypass validation to delete crucial properties on their user object, potentially locking them out or bypassing future checks.
🔧 Fix: Implemented an allowlist based on the Mongoose schema (`models/User.js`) and validated the `provider` against it before any property deletion occurs.
✅ Verification: Code logic confirmed. Attempting to pass a non-OAuth provider like `password` will now result in an `Invalid OAuth Provider` flash message and a redirect.

---
*PR created automatically by Jules for task [9978487075829863123](https://jules.google.com/task/9978487075829863123) started by @mbarbine*